### PR TITLE
list-templates subcommand

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `list-templates` subcommand is now available for the `new` command, allowing to get the list of available Action templates
+  - subcommand can be used with `--json` flag, which will format the output as JSON
+
 ## 0.10.0 - 2024-05-20
 
 - A `version` is now available in the metadata to signal the current version of the metadata format.

--- a/action_server/src/sema4ai/action_server/_cli_helpers.py
+++ b/action_server/src/sema4ai/action_server/_cli_helpers.py
@@ -27,3 +27,11 @@ def add_verbose_args(parser, defaults):
         default=False,
         help="Be more talkative (default: %(default)s)",
     )
+
+
+def add_json_output_args(parser):
+    parser.add_argument(
+        "--json",
+        help="Write output to stdout in json format",
+        action="store_true",
+    )

--- a/action_server/src/sema4ai/action_server/_cli_impl.py
+++ b/action_server/src/sema4ai/action_server/_cli_impl.py
@@ -292,7 +292,7 @@ def _create_parser():
     #     ),
     #     nargs="?",
     # )
-    
+
     # New project from template
     _add_new_command(command_subparser, defaults)
 

--- a/action_server/src/sema4ai/action_server/_cli_impl.py
+++ b/action_server/src/sema4ai/action_server/_cli_impl.py
@@ -21,7 +21,6 @@ from ._protocols import (
     ArgumentsNamespaceDownloadRcc,
     ArgumentsNamespaceImport,
     ArgumentsNamespaceMigrateImportOrStart,
-    ArgumentsNamespaceNew,
     ArgumentsNamespaceStart,
 )
 
@@ -209,8 +208,40 @@ def _add_import_command(command_subparser, defaults):
     _add_whitelist_args(import_parser, defaults)
 
 
+def _add_new_command(command_subparser, defaults):
+    from sema4ai.action_server._cli_helpers import (
+        add_json_output_args,
+        add_verbose_args,
+    )
+
+    new_parser = command_subparser.add_parser(
+        "new",
+        help="Bootstrap new project from template",
+    )
+
+    new_parser.add_argument(
+        "--name",
+        help="Name for the project",
+    )
+
+    new_parser.add_argument(
+        "--template",
+        help="Action template for the project",
+    )
+
+    add_verbose_args(new_parser, defaults)
+
+    new_subparsers = new_parser.add_subparsers(dest="new_command")
+
+    list_templates_parser = new_subparsers.add_parser(
+        "list-templates", help="List the available templates"
+    )
+
+    add_verbose_args(list_templates_parser, defaults)
+    add_json_output_args(list_templates_parser)
+
+
 def _create_parser():
-    from sema4ai.action_server._cli_helpers import add_verbose_args
     from sema4ai.action_server.package._package_build_cli import add_package_command
 
     from ._settings import Settings
@@ -230,6 +261,9 @@ def _create_parser():
     # Import
     _add_import_command(command_subparser, defaults)
 
+    # New project from template
+    _add_new_command(command_subparser, defaults)
+
     # Download RCC
     rcc_parser = command_subparser.add_parser(
         "download-rcc",
@@ -245,24 +279,6 @@ def _create_parser():
         help="Target file to where RCC should be downloaded",
         nargs="?",
     )
-
-    # New project from template
-    new_parser = command_subparser.add_parser(
-        "new",
-        help="Bootstrap new project from template",
-    )
-
-    new_parser.add_argument(
-        "--name",
-        help="Name for the project",
-    )
-
-    new_parser.add_argument(
-        "--template",
-        help="Action template for the project",
-    )
-
-    add_verbose_args(new_parser, defaults)
 
     # Schema
     # schema_parser = command_subparser.add_parser(
@@ -518,12 +534,9 @@ def _main_retcode(
     )
 
     if command == "new":
-        new_args: ArgumentsNamespaceNew = typing.cast(ArgumentsNamespaceNew, base_args)
-        from ._new_project import create_new_project
+        from ._new_project import handle_new_command
 
-        return create_new_project(
-            directory=new_args.name, template_name=new_args.template
-        )
+        return handle_new_command(base_args)
 
     migrate_import_or_start_args = typing.cast(
         ArgumentsNamespaceMigrateImportOrStart, base_args

--- a/action_server/src/sema4ai/action_server/_cli_impl.py
+++ b/action_server/src/sema4ai/action_server/_cli_impl.py
@@ -261,9 +261,6 @@ def _create_parser():
     # Import
     _add_import_command(command_subparser, defaults)
 
-    # New project from template
-    _add_new_command(command_subparser, defaults)
-
     # Download RCC
     rcc_parser = command_subparser.add_parser(
         "download-rcc",
@@ -295,6 +292,9 @@ def _create_parser():
     #     ),
     #     nargs="?",
     # )
+    
+    # New project from template
+    _add_new_command(command_subparser, defaults)
 
     # Version
     command_subparser.add_parser(

--- a/action_server/src/sema4ai/action_server/_new_project.py
+++ b/action_server/src/sema4ai/action_server/_new_project.py
@@ -116,7 +116,7 @@ def handle_list_templates(output_json: bool = False) -> int:
             if len(templates) == 0:
                 log.info("No templates available.")
             else:
-                _print_templates_list(metadata.templates)
+                _print_templates_list(templates)
 
         return 0
     except Exception as e:

--- a/action_server/src/sema4ai/action_server/_new_project_helpers.py
+++ b/action_server/src/sema4ai/action_server/_new_project_helpers.py
@@ -123,3 +123,10 @@ def _get_action_templates_dir_path() -> Path:
 
 def _get_action_templates_metadata_path() -> Path:
     return Path(_get_action_templates_dir_path() / ACTION_TEMPLATES_METADATA_FILENAME)
+
+
+def _print_templates_list(templates: list[ActionTemplate]) -> None:
+    from sema4ai.action_server.vendored_deps.termcolors import colored
+
+    for index, template in enumerate(templates, start=1):
+        log.info(colored(f" > {index}. {template.description}", "cyan"))

--- a/action_server/src/sema4ai/action_server/_protocols.py
+++ b/action_server/src/sema4ai/action_server/_protocols.py
@@ -113,6 +113,13 @@ class ArgumentsNamespaceNew(ArgumentsNamespace):
     command: Literal["new"]
     name: str
     template: str
+    new_command: Literal["list-templates"]
+
+
+class ArgumentsNamespaceNewTemplates(ArgumentsNamespace):
+    command: Literal["new"]
+    new_command: Literal["list-templates"]
+    json: bool
 
 
 class ArgumentsNamespaceEnv(ArgumentsNamespace):

--- a/action_server/tests/action_server_tests/test_cli.py
+++ b/action_server/tests/action_server_tests/test_cli.py
@@ -30,6 +30,32 @@ def test_new(
     check_new_template(tmpdir, action_server_process, client)
 
 
+def test_new_list_templates(tmpdir) -> None:
+    import json
+
+    from sema4ai.action_server._selftest import robocorp_action_server_run
+
+    output = robocorp_action_server_run(
+        ["new", "list-templates"], returncode=0, cwd=tmpdir
+    )
+
+    assert "Minimal" in output.stderr
+    assert "Basic" in output.stderr
+    assert "Advanced" in output.stderr
+
+    output = robocorp_action_server_run(
+        ["new", "list-templates", "--json"], returncode=0, cwd=tmpdir
+    )
+
+    templates: list[dict[str, str]] = json.loads(output.stdout)
+
+    assert len(templates) == 3
+
+    assert templates[0].get("name") == "minimal"
+    assert templates[1].get("name") == "basic"
+    assert templates[2].get("name") == "advanced"
+
+
 def test_help(str_regression):
     import re
 


### PR DESCRIPTION
Adds "list-templates" subcommand for the "new" command, allowing to get templates available for a new project.

Subcommand accepts "--json" flag - when set, output will be formatted as JSON. 

NOTE:
Tests currently check against stderr, as it seems like `new` command writes its output there. Further investigation needed