### PR TITLE
Fix keyring load backend issue

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix issue where keyring backend was not loaded properly with Windows and MacOS
+
 ## 0.12.0 - 2024-05-29
 
 - Add new command: cloud

--- a/action_server/src/sema4ai/action_server/_keyring.py
+++ b/action_server/src/sema4ai/action_server/_keyring.py
@@ -4,6 +4,8 @@ from logging import getLogger
 
 import keyring
 
+# By default in Windows and MacOS the keyring backend is not loaded
+# https://github.com/jaraco/keyring/issues/359
 if sys.platform == "win32":
     keyring.core.set_keyring(
         keyring.core.load_keyring("keyring.backends.Windows.WinVaultKeyring")

--- a/action_server/src/sema4ai/action_server/_keyring.py
+++ b/action_server/src/sema4ai/action_server/_keyring.py
@@ -1,7 +1,17 @@
+import sys
 import typing
 from logging import getLogger
 
 import keyring
+
+if sys.platform == "win32":
+    keyring.core.set_keyring(
+        keyring.core.load_keyring("keyring.backends.Windows.WinVaultKeyring")
+    )
+elif sys.platform == "darwin":
+    keyring.core.set_keyring(
+        keyring.core.load_keyring("keyring.backends.macOS.Keyring")
+    )
 
 log = getLogger(__name__)
 


### PR DESCRIPTION
Tested on windows and it can load the backend, though would still need to test the bundled package.
Testing on macos and it can load the backend, of course need to test this with the bundled package as well.