### PR TITLE
Package build argument --input-dir to choose source dir

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add package build argument --input-dir to choose the action package source directory
 - Package build command to print package path to stdout in json format if --json argument is provided
 - Encrypt-at-rest sensitive storage data to the file system instead of using keyring to store it
 

--- a/action_server/src/sema4ai/action_server/_protocols.py
+++ b/action_server/src/sema4ai/action_server/_protocols.py
@@ -155,6 +155,7 @@ class ArgumentsNamespacePackageUpdate(ArgumentsNamespace):
 class ArgumentsNamespacePackageBuild(ArgumentsNamespace):
     command: Literal["package"]
     package_command: Literal["build"]
+    input_dir: str
     output_dir: str
     datadir: str
     override: bool
@@ -172,6 +173,7 @@ class ArgumentsNamespacePackageMetadata(ArgumentsNamespace):
     command: Literal["package"]
     package_command: Literal["metadata"]
     output_file: Optional[str]
+    input_dir: str
 
 
 class ArgumentsNamespaceMigrateImportOrStart(ArgumentsNamespace):

--- a/action_server/src/sema4ai/action_server/package/_package_build.py
+++ b/action_server/src/sema4ai/action_server/package/_package_build.py
@@ -204,6 +204,8 @@ def build_package(
     args_metadata = [
         "package",
         "metadata",
+        "--input-dir",
+        str(input_dir),
         "--db-file",
         ":memory:",
         "--output-file",

--- a/action_server/src/sema4ai/action_server/package/_package_build_cli.py
+++ b/action_server/src/sema4ai/action_server/package/_package_build_cli.py
@@ -132,6 +132,12 @@ def add_package_command(command_subparser, defaults):
         help="Creates a .zip with the contents of the action package so that it can be deployed",
     )
     build_parser.add_argument(
+        "--input-dir",
+        dest="input_dir",
+        help="The source directory for the action package",
+        default=".",
+    )
+    build_parser.add_argument(
         "--output-dir",
         dest="output_dir",
         help="The output file for saving the action package built file",
@@ -175,6 +181,12 @@ def add_package_command(command_subparser, defaults):
     extract_parser = package_subparsers.add_parser(
         "metadata",
         help="Collects metadata from the action package in the current cwd and prints it to stdout",
+    )
+    extract_parser.add_argument(
+        "--input-dir",
+        dest="input_dir",
+        help="The source directory for the action package",
+        default=".",
     )
     extract_parser.add_argument(
         "--output-file",
@@ -278,7 +290,7 @@ def handle_package_command(base_args: ArgumentsNamespace):
         # action-server package build --output-dir=<zipfile> --datadir=<directory> <source-directory>:
         try:
             result = build_package(
-                Path(".").absolute(),
+                input_dir=Path(package_build_args.input_dir).absolute(),
                 output_dir=package_build_args.output_dir,
                 datadir=package_build_args.datadir,
                 override=package_build_args.override,
@@ -341,7 +353,7 @@ def handle_package_command(base_args: ArgumentsNamespace):
         retcode = 0
         try:
             package_metadata_or_returncode: str | int = collect_package_metadata(
-                Path(".").absolute(),
+                package_dir=Path(package_metadata_args.input_dir).absolute(),
                 datadir=package_metadata_args.datadir,
             )
             if isinstance(package_metadata_or_returncode, str):

--- a/action_server/src/sema4ai/action_server/package/_package_metadata.py
+++ b/action_server/src/sema4ai/action_server/package/_package_metadata.py
@@ -20,7 +20,7 @@ def collect_package_metadata(package_dir: Path, datadir: str) -> str | int:
     from sema4ai.action_server._errors_action_server import ActionServerValidationError
     from sema4ai.action_server._models import Action, ActionPackage, create_db
 
-    args = ["start", "--db-file", ":memory:"]
+    args = ["start", "--db-file", ":memory:", "--dir", str(package_dir)]
     if datadir:
         args.extend(["--datadir", datadir])
 

--- a/action_server/tests/action_server_tests/test_package.py
+++ b/action_server/tests/action_server_tests/test_package.py
@@ -32,6 +32,8 @@ def test_package_zip(datadir):
         [
             "package",
             "build",
+            "--input-dir",
+            str(Path(datadir, "pack1")),
             "--output-dir",
             str(datadir),
             "--datadir",
@@ -132,6 +134,8 @@ def test_package_metadata(datadir, data_regression):
         [
             "package",
             "metadata",
+            "--input-dir",
+            str(Path(datadir, "pack1")),
             "--datadir",
             str(datadir / "data"),
         ],


### PR DESCRIPTION
Add --input-dir argument for the build and the metadata arguments.
The metadata command is called internally from the build command.
The metadata command calls the start command with --dir <input-dir>.