### PR TITLE
Use network settings from RCC profile

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `cwd` is now always reset whenever an action is run (so, changes to the `cwd`
   will not affect a new action run).
+- Use RCC network profile when doing requests
 
 ## 0.14.0 - 2024-06-11
 

--- a/action_server/src/sema4ai/action_server/_cli_impl.py
+++ b/action_server/src/sema4ai/action_server/_cli_impl.py
@@ -553,8 +553,8 @@ def _main_retcode(
         download_rcc(target=download_args.file, force=True)
         return 0
 
-    from sema4ai.action_server._rcc import initialize_rcc
     from sema4ai.action_server._download_rcc import download_rcc
+    from sema4ai.action_server._rcc import initialize_rcc
     from sema4ai.action_server._session import initialize_session
 
     with initialize_rcc(download_rcc(), None) as rcc:
@@ -593,9 +593,9 @@ def _main_retcode(
         )
 
         if command == "new":
-            from ._new_project import handle_new_command
-
             from sema4ai.action_server._download_rcc import download_rcc
+
+            from ._new_project import handle_new_command
 
             return handle_new_command(base_args)
 

--- a/action_server/src/sema4ai/action_server/_cli_impl.py
+++ b/action_server/src/sema4ai/action_server/_cli_impl.py
@@ -570,7 +570,7 @@ def _main_retcode(
         if command == "env":
             from sema4ai.action_server.env import handle_env_command
 
-            return handle_env_command(base_args)
+            return handle_env_command(base_args, rcc)
 
         if command == "cloud":
             from sema4ai.action_server._actions_cloud import handle_cloud_command

--- a/action_server/src/sema4ai/action_server/_new_project_helpers.py
+++ b/action_server/src/sema4ai/action_server/_new_project_helpers.py
@@ -6,7 +6,6 @@ import zipfile
 from pathlib import Path
 from typing import Optional, TypedDict
 
-import requests
 import yaml
 from pydantic.main import BaseModel
 
@@ -43,13 +42,15 @@ def _ensure_latest_templates() -> None:
     # Ensures the existence of the latest templates package.
     # It downloads the latest templates metadata file, and compares the hash with the metadata held locally (if exists).
     # If there is no match (or metadata is not available locally), it will download the templates package.
+    from sema4ai.action_server._session import session
+
     action_templates_dir_path = _get_action_templates_dir_path()
 
     os.makedirs(action_templates_dir_path, exist_ok=True)
 
     local_metadata = _get_local_templates_metadata()
 
-    response = requests.get(TEMPLATES_METADATA_URL)
+    response = session.get(TEMPLATES_METADATA_URL)
     response.raise_for_status()
 
     new_metadata_content = response.text
@@ -68,7 +69,9 @@ def _ensure_latest_templates() -> None:
 
 
 def _download_and_unzip_templates(action_templates_dir: Path) -> None:
-    templates_response = requests.get(TEMPLATES_PACKAGE_URL)
+    from sema4ai.action_server._session import session
+
+    templates_response = session.get(TEMPLATES_PACKAGE_URL)
 
     with zipfile.ZipFile(io.BytesIO(templates_response.content)) as zip_ref:
         zip_ref.extractall(action_templates_dir)

--- a/action_server/src/sema4ai/action_server/_rcc.py
+++ b/action_server/src/sema4ai/action_server/_rcc.py
@@ -348,6 +348,10 @@ class Rcc(object):
         self._add_config_to_args(args)
         self._run_rcc(args, timeout=600, show_interactive_output=True)
 
+    def get_network_settings(self) -> ActionResult:
+        args = ["config", "settings", "--json"]
+        return self._run_rcc(args)
+
 
 _rcc: Optional["Rcc"] = None
 

--- a/action_server/src/sema4ai/action_server/_rcc.py
+++ b/action_server/src/sema4ai/action_server/_rcc.py
@@ -361,14 +361,15 @@ def initialize_rcc(rcc_location: Path, robocorp_home: Optional[Path]) -> Iterato
     global _rcc
 
     if _rcc:
-        raise Exception("RCC already initialized")
+        yield _rcc
 
-    rcc = Rcc(rcc_location, robocorp_home)
-    _rcc = rcc
-    try:
-        yield rcc
-    finally:
-        _rcc = None
+    if not _rcc:
+        rcc = Rcc(rcc_location, robocorp_home)
+        _rcc = rcc
+        try:
+            yield rcc
+        finally:
+            _rcc = None
 
 
 def get_rcc() -> Rcc:

--- a/action_server/src/sema4ai/action_server/_rcc.py
+++ b/action_server/src/sema4ai/action_server/_rcc.py
@@ -360,6 +360,9 @@ _rcc: Optional["Rcc"] = None
 def initialize_rcc(rcc_location: Path, robocorp_home: Optional[Path]) -> Iterator[Rcc]:
     global _rcc
 
+    if _rcc:
+        raise Exception("RCC already initialized")
+
     rcc = Rcc(rcc_location, robocorp_home)
     _rcc = rcc
     try:

--- a/action_server/src/sema4ai/action_server/_rcc.py
+++ b/action_server/src/sema4ai/action_server/_rcc.py
@@ -362,14 +362,14 @@ def initialize_rcc(rcc_location: Path, robocorp_home: Optional[Path]) -> Iterato
 
     if _rcc:
         yield _rcc
+        return
 
-    if not _rcc:
-        rcc = Rcc(rcc_location, robocorp_home)
-        _rcc = rcc
-        try:
-            yield rcc
-        finally:
-            _rcc = None
+    rcc = Rcc(rcc_location, robocorp_home)
+    _rcc = rcc
+    try:
+        yield rcc
+    finally:
+        _rcc = None
 
 
 def get_rcc() -> Rcc:

--- a/action_server/src/sema4ai/action_server/_session.py
+++ b/action_server/src/sema4ai/action_server/_session.py
@@ -1,11 +1,9 @@
 import logging
 import os
-import ssl
 from typing import TYPE_CHECKING, Optional
 
 import requests
 from pydantic import BaseModel, Field
-from requests.adapters import HTTPAdapter
 
 if TYPE_CHECKING:
     from sema4ai.action_server._rcc import Rcc

--- a/action_server/src/sema4ai/action_server/_session.py
+++ b/action_server/src/sema4ai/action_server/_session.py
@@ -19,6 +19,7 @@ class RccCertificateSettings(BaseModel):
 class RccNetworkSettings(BaseModel):
     http_proxy: Optional[str] = Field(default=None, alias="http-proxy")
     https_proxy: Optional[str] = Field(default=None, alias="https-proxy")
+    no_proxy: Optional[str] = Field(default=None, alias="no-proxy")
 
 
 class RccSettings(BaseModel):
@@ -55,6 +56,7 @@ def initialize_session(rcc: "Rcc"):
 
     http_proxy = settings.network.http_proxy if settings.network else None
     https_proxy = settings.network.https_proxy if settings.network else None
+    no_proxy = settings.network.no_proxy if settings.network else None
     verify_ssl = (
         settings.certificates.verify_ssl
         if settings.certificates is not None
@@ -71,6 +73,9 @@ def initialize_session(rcc: "Rcc"):
         os.environ["https_proxy"] = https_proxy
         os.environ["HTTPS_PROXY"] = https_proxy
         session.proxies["https"] = https_proxy
+
+    if no_proxy:
+        os.environ["NO_PROXY"] = no_proxy
 
     if not verify_ssl:
         os.environ["REQUESTS_CA_BUNDLE"] = ""

--- a/action_server/src/sema4ai/action_server/_session.py
+++ b/action_server/src/sema4ai/action_server/_session.py
@@ -1,7 +1,8 @@
-import requests
-import os
 import json
+import os
 import typing
+
+import requests
 
 if typing.TYPE_CHECKING:
     from sema4ai.action_server._rcc import Rcc
@@ -19,7 +20,7 @@ def initialize_session(rcc: "Rcc"):
     global session
 
     result = rcc.get_network_settings()
-    if result.success:
+    if result.success and result.result:
         network_settings = json.loads(result.result)
     else:
         raise Exception("Failed to load RCC profile settings")

--- a/action_server/src/sema4ai/action_server/_session.py
+++ b/action_server/src/sema4ai/action_server/_session.py
@@ -102,6 +102,7 @@ def initialize_session(rcc: "Rcc"):
     legacy_renegotiation_allowed = (
         settings.certificates.legacy_renegotiation_allowed
         if settings.certificates
+        and settings.certificates.legacy_renegotiation_allowed is not None
         else False
     )
 

--- a/action_server/src/sema4ai/action_server/_session.py
+++ b/action_server/src/sema4ai/action_server/_session.py
@@ -98,4 +98,4 @@ def initialize_session(rcc: "Rcc"):
         # The robocorp-truststore package uses this environment variable to
         # check if the legacy renegotiation is allowed and will enable it for
         # all requests
-        os.environ["RC_TLS_LEGACY_RENEGOTIATION_ALLOWED"] = True
+        os.environ["RC_TLS_LEGACY_RENEGOTIATION_ALLOWED"] = "True"

--- a/action_server/src/sema4ai/action_server/_session.py
+++ b/action_server/src/sema4ai/action_server/_session.py
@@ -42,7 +42,13 @@ def initialize_session(rcc: "Rcc"):
 
     result = rcc.get_network_settings()
     if result.success and result.result:
-        settings = RccSettings.model_validate_json(result.result, strict=False)
+        try:
+            settings = RccSettings.model_validate_json(result.result, strict=False)
+        except ValueError:
+            log.critical(
+                bold_red(f"Failed to read RCC profile settings: {result.result}")
+            )
+            return
     else:
         log.critical(bold_red("Failed to load RCC profile settings"))
         return

--- a/action_server/src/sema4ai/action_server/_session.py
+++ b/action_server/src/sema4ai/action_server/_session.py
@@ -1,0 +1,56 @@
+import requests
+import os
+import json
+import typing
+
+if typing.TYPE_CHECKING:
+    from sema4ai.action_server._rcc import Rcc
+
+session = requests.Session()
+
+
+def initialize_session(rcc: "Rcc"):
+    """
+    Initialize the requests session with RCC profile settings.
+
+    Args:
+        rcc: Rcc instance to load the profiles from.
+    """
+    global session
+
+    result = rcc.get_network_settings()
+    if result.success:
+        network_settings = json.loads(result.result)
+    else:
+        raise Exception("Failed to load RCC profile settings")
+
+    network = network_settings["network"] if "network" in network_settings else None
+    http_proxy = network["http-proxy"] if network and "http-proxy" in network else None
+    https_proxy = (
+        network["https-proxy"] if network and "https-proxy" in network else None
+    )
+
+    certificates = (
+        network_settings["certificates"] if "certificates" in network_settings else None
+    )
+    verify_ssl = (
+        certificates["verify-ssl"]
+        if certificates and "verify-ssl" in certificates
+        else True
+    )
+
+    if http_proxy:
+        os.environ["http_proxy"] = http_proxy
+        os.environ["HTTP_PROXY"] = http_proxy
+        session.proxies["http"] = http_proxy
+
+    if https_proxy:
+        os.environ["https_proxy"] = https_proxy
+        os.environ["HTTPS_PROXY"] = https_proxy
+        session.proxies["https"] = https_proxy
+
+    if not verify_ssl:
+        os.environ["REQUESTS_CA_BUNDLE"] = ""
+        os.environ["CURL_CA_BUNDLE"] = ""
+
+    session.verify = verify_ssl

--- a/action_server/src/sema4ai/action_server/env/__init__.py
+++ b/action_server/src/sema4ai/action_server/env/__init__.py
@@ -1,11 +1,15 @@
 import logging
+import typing
 
 from sema4ai.action_server._protocols import ArgumentsNamespace, ArgumentsNamespaceEnv
+
+if typing.TYPE_CHECKING:
+    from sema4ai.action_server._rcc import Rcc
 
 log = logging.getLogger(__name__)
 
 
-def handle_env_command(env_args: ArgumentsNamespace):
+def handle_env_command(env_args: ArgumentsNamespace, rcc: "Rcc"):
     import typing
 
     env_command = typing.cast(ArgumentsNamespaceEnv, env_args).env_command
@@ -15,14 +19,7 @@ def handle_env_command(env_args: ArgumentsNamespace):
 
     if env_command == "clean-tools-caches":
         log.info("Clearing tools caches, please wait...")
-        from sema4ai.action_server._download_rcc import download_rcc
-        from sema4ai.action_server._rcc import initialize_rcc
-
-        robocorp_home = None
-
-        with initialize_rcc(download_rcc(force=False), robocorp_home) as rcc:
-            rcc.clean_tools_caches()
-
+        rcc.clean_tools_caches()
         return 0
 
     log.critical(f"Env command not recognized: {env_command}.")

--- a/action_server/src/sema4ai/action_server/package/_package_publish_api.py
+++ b/action_server/src/sema4ai/action_server/package/_package_publish_api.py
@@ -148,6 +148,8 @@ def get_nonce() -> str:
 def create_package(
     organization_id: str, name: str, access_credentials: str, hostname: str
 ) -> ActionPackageEntityResponse:
+    from sema4ai.action_server._session import session
+
     log.debug(f"Creating action package entity: {name}")
 
     url = parse_url(
@@ -174,7 +176,7 @@ def create_package(
     }
 
     try:
-        r = requests.post(url.geturl(), data=data, headers=headers)
+        r = session.post(url.geturl(), data=data, headers=headers)
     except requests.exceptions.ConnectionError as e:
         raise ActionServerValidationError(f"Failed to call Controm Room API: {e}")
 
@@ -196,6 +198,8 @@ def create_package(
 def get_upload_url(
     organization_id: str, package_id: str, access_credentials: str, hostname: str
 ) -> str:
+    from sema4ai.action_server._session import session
+
     log.debug(f"Getting upload URL for: {package_id}")
 
     url = parse_url(
@@ -224,7 +228,7 @@ def get_upload_url(
     }
 
     try:
-        r = requests.post(url.geturl(), data=data, headers=headers)
+        r = session.post(url.geturl(), data=data, headers=headers)
     except requests.exceptions.ConnectionError as e:
         raise ActionServerValidationError(f"Failed to call Controm Room API: {e}")
 
@@ -244,10 +248,12 @@ def get_upload_url(
 
 
 def upload_file(url: str, pkg_path: Path) -> None:
+    from sema4ai.action_server._session import session
+
     log.debug(f"Uploading file: {pkg_path.resolve()}")
 
     with open(pkg_path, "rb") as f:
-        r = requests.put(url, data=f)
+        r = session.put(url, data=f)
 
         if r.ok:
             log.debug("File uploaded successfully")
@@ -260,6 +266,8 @@ def upload_file(url: str, pkg_path: Path) -> None:
 def request_package_status(
     organization_id: str, package_id: str, access_credentials: str, hostname: str
 ) -> ActionPackageEntityResponse:
+    from sema4ai.action_server._session import session
+
     log.debug(f"Getting action package publish status: {package_id}")
 
     url = parse_url(
@@ -288,7 +296,7 @@ def request_package_status(
     }
 
     try:
-        r = requests.get(url.geturl(), headers=headers)
+        r = session.get(url.geturl(), headers=headers)
     except requests.exceptions.ConnectionError as e:
         raise ActionServerValidationError(f"Failed to call Controm Room API: {e}")
 
@@ -308,6 +316,8 @@ def request_package_status(
 
 
 def request_organizations(url: str, access_credentials: str) -> OrganizationsResponse:
+    from sema4ai.action_server._session import session
+
     parsed_url = parse_url(url)
 
     api_key_id, secret = split_access_credentials(access_credentials)
@@ -331,7 +341,7 @@ def request_organizations(url: str, access_credentials: str) -> OrganizationsRes
     }
 
     try:
-        r = requests.get(parsed_url.geturl(), headers=headers)
+        r = session.get(parsed_url.geturl(), headers=headers)
     except requests.exceptions.ConnectionError as e:
         raise ActionServerValidationError(f"Failed to call Controm Room API: {e}")
 
@@ -357,6 +367,8 @@ def mark_upload_completed(
     hostname: str,
     s3_object_key: str,
 ) -> None:
+    from sema4ai.action_server._session import session
+
     url = parse_url(
         UPLOAD_COMPLETED_URL.substitute(
             HOSTNAME=hostname, ORG_ID=organization_id, ACTION_PACKAGE_ID=package_id
@@ -384,7 +396,7 @@ def mark_upload_completed(
     }
 
     try:
-        r = requests.post(url.geturl(), data=data, headers=headers)
+        r = session.post(url.geturl(), data=data, headers=headers)
     except requests.exceptions.ConnectionError as e:
         raise ActionServerValidationError(f"Failed to call Controm Room API: {e}")
 
@@ -401,6 +413,8 @@ def request_package_changelog_update(
     changelog: str,
     hostname: str,
 ) -> ActionPackageEntityResponse:
+    from sema4ai.action_server._session import session
+
     url = parse_url(
         UPDATE_CHANGELOG_URL.substitute(
             HOSTNAME=hostname, ORG_ID=organization_id, ACTION_PACKAGE_ID=package_id
@@ -428,7 +442,7 @@ def request_package_changelog_update(
     }
 
     try:
-        r = requests.post(url.geturl(), data=data, headers=headers)
+        r = session.post(url.geturl(), data=data, headers=headers)
     except requests.exceptions.ConnectionError as e:
         raise ActionServerValidationError(f"Failed to call Controm Room API: {e}")
 

--- a/action_server/tests/action_server_tests/test_create_new_project.py
+++ b/action_server/tests/action_server_tests/test_create_new_project.py
@@ -8,7 +8,7 @@ import sema4ai.action_server._new_project
 
 
 @mock.patch(
-    "sema4ai.action_server._new_project_helpers.requests.get",
+    "sema4ai.action_server._session.session.get",
     side_effect=requests.exceptions.HTTPError,
 )
 @mock.patch(
@@ -44,7 +44,7 @@ def test_create_new_project_download_metadata_fail(
 
 
 @mock.patch(
-    "sema4ai.action_server._new_project_helpers.requests.get",
+    "sema4ai.action_server._session.session.get",
     side_effect=requests.exceptions.HTTPError,
 )
 @mock.patch(

--- a/action_server/tests/action_server_tests/test_session.py
+++ b/action_server/tests/action_server_tests/test_session.py
@@ -1,0 +1,77 @@
+import json
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
+from sema4ai.action_server._rcc import ActionResult
+
+
+@patch("sema4ai.action_server._session.session")
+def test_session_empty_settings(session_mock: MagicMock):
+    from sema4ai.action_server._session import initialize_session
+
+    type(session_mock).proxies = PropertyMock(return_value={})
+
+    rcc = Mock()
+    rcc.get_network_settings.return_value = ActionResult(True, None, json.dumps({}))
+
+    initialize_session(rcc)
+
+    assert session_mock.verify is True
+    assert hasattr(session_mock.proxies, "http") is False
+    assert hasattr(session_mock.proxies, "https") is False
+
+
+@patch("sema4ai.action_server._session.session")
+def test_session_set_proxies(session_mock: MagicMock):
+    from sema4ai.action_server._session import initialize_session
+
+    type(session_mock).proxies = PropertyMock(return_value={})
+
+    settings = {
+        "network": {"http-proxy": "http://testing", "https-proxy": "https://testing"}
+    }
+
+    rcc = Mock()
+    rcc.get_network_settings.return_value = ActionResult(
+        True, None, json.dumps(settings)
+    )
+
+    initialize_session(rcc)
+
+    assert session_mock.verify is True
+    assert session_mock.proxies["http"] == "http://testing"
+    assert session_mock.proxies["https"] == "https://testing"
+
+
+@patch("sema4ai.action_server._session.session")
+def test_session_disable_ssl_verify(session_mock: MagicMock):
+    from sema4ai.action_server._session import initialize_session
+
+    type(session_mock).proxies = PropertyMock(return_value={})
+
+    settings = {"certificates": {"verify-ssl": False}}
+
+    rcc = Mock()
+    rcc.get_network_settings.return_value = ActionResult(
+        True, None, json.dumps(settings)
+    )
+
+    initialize_session(rcc)
+
+    assert session_mock.verify is False
+    assert hasattr(session_mock.proxies, "http") is False
+    assert hasattr(session_mock.proxies, "https") is False
+
+
+@patch("sema4ai.action_server._session.session")
+def test_session_fail_to_read_settings(session_mock: MagicMock):
+    from sema4ai.action_server._session import initialize_session
+
+    type(session_mock).proxies = PropertyMock(return_value={})
+
+    rcc = Mock()
+    rcc.get_network_settings.return_value = ActionResult(False, None, json.dumps({}))
+
+    initialize_session(rcc)
+
+    assert hasattr(session_mock.proxies, "http") is False
+    assert hasattr(session_mock.proxies, "https") is False

--- a/templates/advanced/actions.py
+++ b/templates/advanced/actions.py
@@ -6,7 +6,6 @@ https://github.com/sema4ai/actions/blob/master/README.md
 
 """
 
-import requests
 from sema4ai.actions import action, Secret
 from pydantic import BaseModel, Field
 
@@ -18,9 +17,7 @@ class RepositoryInfo(BaseModel):
 
 @action(is_consequential=False)
 def get_repository_commits(
-        github_access_token: Secret,
-        repository_info: RepositoryInfo,
-        limit: int = 10
+    github_access_token: Secret, repository_info: RepositoryInfo, limit: int = 10
 ) -> str:
     """
     Returns commit messages from given repository.
@@ -33,20 +30,23 @@ def get_repository_commits(
     Returns:
         A list of commit messages.
     """
+    from sema4ai.action_server._session import session
 
     if limit < 1 or limit > 100:
         return "Limit must be between 1 and 100"
 
-    response = requests.get(f"https://api.github.com/repos/{repository_info.owner_id}/{repository_info.name}/commits?per_page={limit}",
-                            headers={
-                                'Authorization': 'Bearer ' + github_access_token.value,
-                                'Content-Type': 'application/x-www-form-urlencoded'
-                            })
+    response = session.get(
+        f"https://api.github.com/repos/{repository_info.owner_id}/{repository_info.name}/commits?per_page={limit}",
+        headers={
+            "Authorization": "Bearer " + github_access_token.value,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
 
     items = response.json()
-    commit_messages = [item['commit']['message'] for item in items]
+    commit_messages = [item["commit"]["message"] for item in items]
 
-    output = '\n'.join(commit_messages)
+    output = "\n".join(commit_messages)
 
     # Pretty print for log
     print(output)

--- a/templates/advanced/actions.py
+++ b/templates/advanced/actions.py
@@ -8,6 +8,7 @@ https://github.com/sema4ai/actions/blob/master/README.md
 
 from sema4ai.actions import action, Secret
 from pydantic import BaseModel, Field
+import requests
 
 
 class RepositoryInfo(BaseModel):
@@ -30,12 +31,10 @@ def get_repository_commits(
     Returns:
         A list of commit messages.
     """
-    from sema4ai.action_server._session import session
-
     if limit < 1 or limit > 100:
         return "Limit must be between 1 and 100"
 
-    response = session.get(
+    response = requests.get(
         f"https://api.github.com/repos/{repository_info.owner_id}/{repository_info.name}/commits?per_page={limit}",
         headers={
             "Authorization": "Bearer " + github_access_token.value,


### PR DESCRIPTION
Read the RCC profile settings and take them into use when doing http requests.

Create a singleton requests.Session object that has the settings enabled.
Use the singleton instead of requests.

TODO: should we return from action server if we fail to read the RCC profile settings? Currently it will just log a critical message but will proceed.