### PR TITLE
Fixed predict template model engine

### DIFF
--- a/templates/data-access-predict/data_sources.py
+++ b/templates/data-access-predict/data_sources.py
@@ -57,8 +57,12 @@ HouseSalesModelDataSource = Annotated[
             CREATE MODEL models.house_sales_model
             FROM files
             (SELECT * FROM house_sales) 
-            PREDICT MA ORDER BY saledate GROUP BY bedrooms, type -- as the data is quarterly, look back two years to forecast the next one year WINDOW 8 HORIZON 4 -- use the statsforecast engine for this model
-            USING engine = 'statsforecast';
+            PREDICT MA
+            ORDER BY saledate
+            GROUP BY bedrooms, type
+            WINDOW 8
+            HORIZON 4 
+            USING engine = 'lightwood';
         """,
     ),
 ]

--- a/templates/data-access-predict/scratchpad.sql
+++ b/templates/data-access-predict/scratchpad.sql
@@ -55,7 +55,7 @@ Dataset source: https://www.kaggle.com/datasets/htagholdings/property-sales
 
 SELECT * FROM files.house_sales;
 
--- The model is created using the stats engine with the prediction target being median price in the period (MA).
+-- The model is created using the lightwood engine with the prediction target being median price in the period (MA).
 CREATE MODEL models.house_sales_model
 FROM files
 (SELECT * FROM house_sales)
@@ -65,10 +65,10 @@ GROUP BY bedrooms, type
 -- as the data is quarterly, look back two years to forecast the next one year
 WINDOW 8
 HORIZON 4
--- use the statsforecast engine for this model
-USING engine = 'statsforecast';
+USING engine = 'lightwood';
 
 DESCRIBE MODEL models.house_sales_model;
+
 DROP MODEL IF EXISTS models.house_sales_model;
 
 -- To use the model to predict the median price in the period (MA) for houses


### PR DESCRIPTION
Our tooling (Studio/CR/ACE) does not support custom model engines nicely, so reverting one of the examples back to lightwood despite the poor model performance. At least it "works".