### PR TITLE
Filename is required in multipart file upload

### DIFF
--- a/actions/docs/CHANGELOG.md
+++ b/actions/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.6 - 2025-03-12
+
+- Pass filename in multipart form data when uploading file.
+
 ## 1.3.5 - 2025-02-15
 
 - Fixed error message to show correct url if upload fails.

--- a/actions/pyproject.toml
+++ b/actions/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-actions"
-version = "1.3.5"
+version = "1.3.6"
 description = "Sema4AI Actions"
 authors = [
 	"Fabio Z. <fabio@sema4.ai>",

--- a/actions/src/sema4ai/actions/__init__.py
+++ b/actions/src/sema4ai/actions/__init__.py
@@ -42,7 +42,7 @@ from ._response import ActionError, Response
 from ._secret import OAuth2Secret, Secret
 from ._table import Row, RowValue, Table
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 version_info = [int(x) for x in __version__.split(".")]
 
 

--- a/actions/src/sema4ai/actions/chat/_client.py
+++ b/actions/src/sema4ai/actions/chat/_client.py
@@ -211,7 +211,8 @@ files will be stored."""
                 # Add the file to the request after the form data (the order
                 # of the fields is important -- the "key" field must
                 # be the first field).
-                fields.append(("file", content))
+                filename = "file"
+                fields.append(("file", (filename, content)))
 
                 encoded_data, content_type = encode_multipart_formdata(fields)
 

--- a/actions/src/sema4ai/actions/chat/_client.py
+++ b/actions/src/sema4ai/actions/chat/_client.py
@@ -211,7 +211,6 @@ files will be stored."""
                 # Add the file to the request after the form data (the order
                 # of the fields is important -- the "key" field must
                 # be the first field).
-                filename = "file"
                 fields.append(("file", (filename, content)))
 
                 encoded_data, content_type = encode_multipart_formdata(fields)


### PR DESCRIPTION
## Context

It seems that the [library](https://www.npmjs.com/package/multer) we use for uploading files does not "extract" the file from the multipart body request if `filename` is not specified.. 

A [quick look](https://github.com/expressjs/multer/blob/master/lib/make-middleware.js#L99) reveals that if the filename is not specified in the multipart request, the file uploading is possibly skipped entirely. 

Even if we should be probably more flexible on the backend side, for the sake of time, we prefer to patch the file actions and provide the required field.

[Discussion on Slack](https://sema4ai.slack.com/archives/C084H2PSZTK/p1741701060702769)

## More Evidence

We tested the behaviour with an agent.

TLTR
* ` fields.append(("file", ("hello.txt", "Hello!")))` OK
*  `fields.append(("file", "Hello!"))` NOT OK.

[agent-package.zip](https://github.com/user-attachments/files/19195206/agent-package.zip)
