### PR TITLE
Removed predict templates from sdk

### DIFF
--- a/templates/packaging/templates-beta.json
+++ b/templates/packaging/templates-beta.json
@@ -25,11 +25,6 @@
             "id": "data-access-native",
             "name": "Data Access/Native Query",
             "desc": "Give agents access to a data source using native (named) queries."
-        },
-        {
-            "id": "data-access-predict",
-            "name": "Data Access/Predict",
-            "desc": "Train predictive models and expose predict actions to agents."
         }
     ]
 }

--- a/templates/packaging/templates-prod.json
+++ b/templates/packaging/templates-prod.json
@@ -25,11 +25,6 @@
             "id": "data-access-native",
             "name": "Data Access/Native Query",
             "desc": "Give agents access to a data source using native (named) queries."
-        },
-        {
-            "id": "data-access-predict",
-            "name": "Data Access/Predict",
-            "desc": "Train predictive models and expose predict actions to agents."
         }
     ]
 }


### PR DESCRIPTION
Data Access support for predictions is deprecated. Removing the templates from the manifest - leave them in the repo for now.