### PR TITLE
If the `x-action-invocation-context` header is present, it should not…

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.14.3 - 2025-09-09
+
 - If the `x-action-invocation-context` header is present, it should not change how the arguments are processed in the MCP use case.
 
 ## 2.14.2 - 2025-08-27

--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- If the `x-action-invocation-context` header is present, it should not change how the arguments are processed in the MCP use case.
+
 ## 2.14.2 - 2025-08-27
 
 - CVE fixes: mcp 1.10.0 or later required

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-action-server"
-version = "2.14.2"
+version = "2.14.3"
 description = """Sema4AI Action Server"""
 authors = ["Fabio Z. <fabio@robocorp.com>"]
 readme = "README.md"

--- a/action_server/src/sema4ai/action_server/__init__.py
+++ b/action_server/src/sema4ai/action_server/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-__version__ = "2.14.2"
+__version__ = "2.14.3"
 version_info = [int(x) for x in __version__.split(".")]
 
 __all__: List[str] = []

--- a/action_server/src/sema4ai/action_server/_actions_run.py
+++ b/action_server/src/sema4ai/action_server/_actions_run.py
@@ -644,23 +644,7 @@ def generate_func_from_action(
         headers = dict((x[0].lower(), x[1]) for x in request.headers.items())
         cookies = dict(request.cookies)
         response_handler = ResponseHandler(response)
-        return await func_internal(response_handler, inputs, headers, cookies)
 
-    async def func_internal(
-        response_handler: IResponseHandler, inputs: Any, headers: dict, cookies: dict
-    ) -> Any:
-        """
-        This is an internal function that actually runs an action (in the threadpool) based on the user's inputs.
-
-        Args:
-            response_handler: The response handler to use (where we can set the run id and whether an async completion was done).
-            inputs: The inputs to the action (gotten from the request based on the agent input).
-            headers: The headers to the action (gotten from the request).
-            cookies: The cookies to the action (gotten from the request).
-
-        Returns:
-            The result of the action.
-        """
         # i.e.: if the `x-action-invocation-context` header is present, we
         # expect it to contain a data envelope (`base64(encrypted_data(JSON.stringify(content)))` or
         # `base64(JSON.stringify(content))`) with the invocation context.
@@ -685,6 +669,23 @@ def generate_func_from_action(
                 headers.update(inputs)
                 inputs = use_inputs
 
+        return await func_internal(response_handler, inputs, headers, cookies)
+
+    async def func_internal(
+        response_handler: IResponseHandler, inputs: Any, headers: dict, cookies: dict
+    ) -> Any:
+        """
+        This is an internal function that actually runs an action (in the threadpool) based on the user's inputs.
+
+        Args:
+            response_handler: The response handler to use (where we can set the run id and whether an async completion was done).
+            inputs: The inputs to the action (gotten from the request based on the agent input).
+            headers: The headers to the action (gotten from the request).
+            cookies: The cookies to the action (gotten from the request).
+
+        Returns:
+            The result of the action.
+        """
         runner = _ActionsRunner(
             action_package,
             action,


### PR DESCRIPTION
… change how the arguments are processes in the MCP use case.