### PR TITLE
Fix to RCC (20.3.2) uv and micromamba extraction check on every command

### DIFF
--- a/action_server/build.py
+++ b/action_server/build.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 # No real build, just download RCC at this point.
 
 # Note: referenced here and in sema4ai.action_server._download_rcc
-RCC_VERSION = "20.3.1"
+RCC_VERSION = "20.3.2"
 
 
 CURDIR = Path(__file__).parent.absolute()

--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.16.1 - 2025-10-09
+
+- RCC v20.3.2: Fix init error of missing `uv` extraction
+
 ## 2.16.0 - 2025-10-08
 
 - RCC v20.3.1: Uses embedded `uv` v0.8.17 for PyPI installations

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-action-server"
-version = "2.16.0"
+version = "2.16.1"
 description = """Sema4AI Action Server"""
 authors = ["Fabio Z. <fabio@robocorp.com>"]
 readme = "README.md"

--- a/action_server/src/sema4ai/action_server/__init__.py
+++ b/action_server/src/sema4ai/action_server/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-__version__ = "2.16.0"
+__version__ = "2.16.1"
 version_info = [int(x) for x in __version__.split(".")]
 
 __all__: List[str] = []

--- a/action_server/src/sema4ai/action_server/_download_rcc.py
+++ b/action_server/src/sema4ai/action_server/_download_rcc.py
@@ -7,7 +7,7 @@ from typing import Optional
 log = logging.getLogger(__name__)
 
 # Note: also referenced in action_server/build.py
-RCC_VERSION = "20.3.1"
+RCC_VERSION = "20.3.2"
 
 
 def get_default_rcc_location() -> Path:

--- a/action_server/tasks.py
+++ b/action_server/tasks.py
@@ -102,7 +102,7 @@ def build_frontend(ctx: Context, debug: bool = False, install: bool = True):
 
     file_contents = {"index.html": index_src.read_bytes()}
 
-    with open(dest_static_contents, "w", encoding="utf-8") as stream:
+    with open(dest_static_contents, "w", encoding="utf-8", newline="\n") as stream:
         print(f"Writing static contents to: {dest_static_contents}")
         stream.write(
             f"""# coding: utf-8
@@ -158,7 +158,7 @@ def build_oauth2_config(ctx: Context):
         "default_user_config": default_user_config_contents,
     }
 
-    with open(dest_path, "w", encoding="utf-8") as stream:
+    with open(dest_path, "w", encoding="utf-8", newline="\n") as stream:
         print(f"Writing OAuth2 configs to: {dest_path}")
         stream.write(
             f"""# coding: utf-8
@@ -349,6 +349,40 @@ def test_binary(ctx: Context, test: str = "", jobs: str = "auto"):
         cwd=str(action_server_dir / "tests"),
         env=env,
     )
+
+
+@task
+def set_rcc_version(ctx: Context, version: str):
+    """Set RCC version in both build.py and _download_rcc.py files."""
+    import re
+    
+    # Files to update
+    files_to_update = [
+        CURDIR / "build.py",
+        CURDIR / "src" / "sema4ai" / "action_server" / "_download_rcc.py"
+    ]
+    
+    for file_path in files_to_update:
+        if not file_path.exists():
+            print(f"Warning: {file_path} does not exist, skipping...")
+            continue
+            
+        # Read current content
+        with open(file_path, "r", encoding="utf-8", newline="\n") as f:
+            content = f.read()
+        
+        # Replace RCC_VERSION = "..." with new version
+        pattern = r'RCC_VERSION = "[^"]*"'
+        replacement = f'RCC_VERSION = "{version}"'
+        new_content = re.sub(pattern, replacement, content)
+        
+        if new_content != content:
+            # Write updated content with LF line endings
+            with open(file_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write(new_content)
+            print(f"Updated {file_path} with RCC version {version}")
+        else:
+            print(f"No RCC_VERSION found in {file_path}")
 
 
 @task


### PR DESCRIPTION
Found that on clean setup running diagnostics did not extract the executables.


https://github.com/user-attachments/assets/a45c2799-06ec-48e8-8d7a-6c633ce9838c



