### PR TITLE
Action Server v2.16.2

### DIFF
--- a/action_server/build.py
+++ b/action_server/build.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 # No real build, just download RCC at this point.
 
 # Note: referenced here and in sema4ai.action_server._download_rcc
-RCC_VERSION = "20.3.2"
+RCC_VERSION = "20.3.3"
 
 
 CURDIR = Path(__file__).parent.absolute()

--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.16.2 - 2025-10-13
+
+- RCC v20.3.3: Fix for the `rcc ht hash` call with `--warranty-voided` problem
+
 ## 2.16.1 - 2025-10-09
 
 - RCC v20.3.2: Fix init error of missing `uv` extraction

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-action-server"
-version = "2.16.1"
+version = "2.16.2"
 description = """Sema4AI Action Server"""
 authors = ["Fabio Z. <fabio@robocorp.com>"]
 readme = "README.md"

--- a/action_server/src/sema4ai/action_server/__init__.py
+++ b/action_server/src/sema4ai/action_server/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-__version__ = "2.16.1"
+__version__ = "2.16.2"
 version_info = [int(x) for x in __version__.split(".")]
 
 __all__: List[str] = []

--- a/action_server/src/sema4ai/action_server/_download_rcc.py
+++ b/action_server/src/sema4ai/action_server/_download_rcc.py
@@ -7,7 +7,7 @@ from typing import Optional
 log = logging.getLogger(__name__)
 
 # Note: also referenced in action_server/build.py
-RCC_VERSION = "20.3.2"
+RCC_VERSION = "20.3.3"
 
 
 def get_default_rcc_location() -> Path:


### PR DESCRIPTION
- Fix for the rcc ht hash bug
  - RCC v20.3.3: `--warranty-voided` handling missing in the new uv extractions causing the problems.