### PR TITLE
Action template updates

### DIFF
--- a/templates/advanced/package.yaml
+++ b/templates/advanced/package.yaml
@@ -14,8 +14,7 @@ dependencies:
     - python=3.12.12
     - uv=0.8.17
   pypi:
-
-    - sema4ai-actions=1.6.2
+    - sema4ai-actions=1.6.4
     - requests=2.32.5
 
 dev-dependencies:
@@ -50,5 +49,6 @@ packaging:
     - ./**/.env
     - ./**/__MACOSX
     - ./**/__pycache__
+    - ./**/*_cache/**
     - ./**/.git
     - ./node_modules/**

--- a/templates/basic/package.yaml
+++ b/templates/basic/package.yaml
@@ -14,7 +14,7 @@ dependencies:
     - python=3.12.12
     - uv=0.8.17
   pypi:
-    - sema4ai-actions=1.6.2
+    - sema4ai-actions=1.6.4
     - robocorp-browser=2.3.5
 
 dev-dependencies:
@@ -49,5 +49,6 @@ packaging:
     - ./**/.env
     - ./**/__MACOSX
     - ./**/__pycache__
+    - ./**/*_cache/**
     - ./**/.git
     - ./node_modules/**

--- a/templates/data-access-kb/package.yaml
+++ b/templates/data-access-kb/package.yaml
@@ -11,11 +11,11 @@ version: 1.0.0
 
 dependencies:
   conda-forge:
-  - python=3.12.12
-  - uv=0.8.17
+    - python=3.12.12
+    - uv=0.8.17
   pypi:
-  - sema4ai-actions=1.6.2
-  - sema4ai-data=1.2.1
+    - sema4ai-actions=1.6.4
+    - sema4ai-data=1.2.1
 
 dev-dependencies:
   conda-forge:
@@ -47,3 +47,8 @@ packaging:
   - ./**/*.pyc
   - ./**/*.zip
   - ./**/.env
+    - ./**/__MACOSX
+    - ./**/__pycache__
+    - ./**/*_cache/**
+    - ./**/.git
+    - ./node_modules/**

--- a/templates/data-access-native/package.yaml
+++ b/templates/data-access-native/package.yaml
@@ -14,7 +14,7 @@ dependencies:
     - python=3.12.12
     - uv=0.8.17
   pypi:
-    - sema4ai-actions=1.6.2
+    - sema4ai-actions=1.6.4
     - sema4ai-data=1.2.1
 
 dev-dependencies:
@@ -49,5 +49,6 @@ packaging:
     - ./**/.env
     - ./**/__MACOSX
     - ./**/__pycache__
+    - ./**/*_cache/**
     - ./**/.git
     - ./node_modules/**

--- a/templates/data-access-query/package.yaml
+++ b/templates/data-access-query/package.yaml
@@ -14,7 +14,7 @@ dependencies:
     - python=3.12.12
     - uv=0.8.17
   pypi:
-    - sema4ai-actions=1.6.2
+    - sema4ai-actions=1.6.4
     - sema4ai-data=1.2.1
 
 dev-dependencies:
@@ -49,5 +49,6 @@ packaging:
     - ./**/.env
     - ./**/__MACOSX
     - ./**/__pycache__
+    - ./**/*_cache/**
     - ./**/.git
     - ./node_modules/**

--- a/templates/minimal/package.yaml
+++ b/templates/minimal/package.yaml
@@ -14,7 +14,7 @@ dependencies:
     - python=3.12.12
     - uv=0.8.17
   pypi:
-    - sema4ai-actions=1.6.2
+    - sema4ai-actions=1.6.4
 
 dev-dependencies:
   conda-forge:
@@ -48,5 +48,6 @@ packaging:
     - ./**/.env
     - ./**/__MACOSX
     - ./**/__pycache__
+    - ./**/*_cache/**
     - ./**/.git
     - ./node_modules/**


### PR DESCRIPTION
- sema4ai-actions to v1.6.4
- Added exclusion rule: `- ./**/*_cache/**` to avoid mypy etc. caches getting to the packages