### PR TITLE
DEV-2387 Separate file name validations on windows vs. unix

### DIFF
--- a/actions/docs/api/sema4ai.actions.chat.md
+++ b/actions/docs/api/sema4ai.actions.chat.md
@@ -24,7 +24,7 @@ Set the content of a file to be used in the current chat.
 
 > The way that the contents are stored may depend on how the action is being run. If the action is being run locally it could be saved in the local filesystem, whereas when running in the cloud it could be saved in a different place, such as an S3 bucket.
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L172)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L204)
 
 ```python
 attach_file_content(
@@ -51,7 +51,7 @@ Raw content of the file
 
 - <b>`Exception`</b>: If the file does not exist (or if it was not possible to retrieve it).
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L202)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L234)
 
 ```python
 get_file_content(name: str) → bytes
@@ -73,7 +73,7 @@ Attaches a file to the current chat.
 
 > The way that the contents are stored may depend on how the action is being run. If the action is being run locally it could be saved in the local filesystem, whereas when running in the cloud it could be saved in a different place, such as an S3 bucket.
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L218)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L250)
 
 ```python
 attach_file(
@@ -98,7 +98,7 @@ Attach a file with JSON content to the current chat.
 
 > The way that the contents are stored may depend on how the action is being run. If the action is being run locally it could be saved in the local filesystem, whereas when running in the cloud it could be saved in a different place, such as an S3 bucket.
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L281)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L313)
 
 ```python
 attach_json(
@@ -128,7 +128,7 @@ Deserialized JSON content.
 
 - <b>`Exception`</b>: If the file does not exist (or if it was not possible to retrieve itor if the content is not valid JSON).
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L301)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L333)
 
 ```python
 get_json(
@@ -151,7 +151,7 @@ Attach a file with text content to the current chat.
 
 > The way that the contents are stored may depend on how the action is being run. If the action is being run locally it could be saved in the local filesystem, whereas when running in the cloud it could be saved in a different place, such as an S3 bucket.
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L327)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L359)
 
 ```python
 attach_text(name: str, contents: str) → None
@@ -174,7 +174,7 @@ Text content of the file.
 
 - <b>`Exception`</b>: If the file does not exist (or if it was not possible to retrieve itor if the content is not valid UTF-8).
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L344)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L376)
 
 ```python
 get_text(name: str) → str
@@ -197,7 +197,7 @@ Raw content of the file
 
 - <b>`Exception`</b>: If the file does not exist.
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L258)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L290)
 
 ```python
 get_file(name: str) → Path
@@ -224,7 +224,7 @@ A list of filenames in the thread.
 ` print(files)`
 ['document.pdf', 'data.json']
 
-[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L361)
+[**Link to source**](https://github.com/sema4ai/actions/tree/master/actions/src/sema4ai/actions/chat/__init__.py#L393)
 
 ```python
 list_files() → list[str]

--- a/actions/src/sema4ai/actions/chat/__init__.py
+++ b/actions/src/sema4ai/actions/chat/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import os
-import platform
+import sys
 import typing
 from functools import lru_cache
 from pathlib import Path
@@ -80,7 +80,7 @@ def _check_that_name_is_valid_in_filesystem(name: str):
     if not name or name in (".", ".."):
         raise ValueError(f"Name '{name}' is not valid.")
 
-    is_windows = platform.system() == "Windows"
+    is_windows = sys.platform == "win32"
 
     if is_windows:
         _check_windows_filename(name)

--- a/actions/src/sema4ai/actions/chat/__init__.py
+++ b/actions/src/sema4ai/actions/chat/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 import typing
 from functools import lru_cache
 from pathlib import Path
@@ -13,19 +14,25 @@ if typing.TYPE_CHECKING:
     from ._client import _Client
 
 
-def _check_that_name_is_valid_in_filesystem(name: str):
+def _check_windows_filename(name: str):
+    """Validate filename for Windows."""
+    # Invalid characters on Windows
     invalid_characters = r'<>:"/\|?*'
     if any(char in name for char in invalid_characters):
         raise ValueError(
-            f"Name {name} contains invalid characters: {invalid_characters}"
+            f"Name '{name}' contains invalid characters: {invalid_characters}"
         )
 
-    # Reserved names:
+    # Control characters (0-31) are also invalid on Windows
+    if any(ord(char) < 32 for char in name):
+        raise ValueError(f"Name '{name}' contains control characters.")
+
+    # Reserved device names (case-insensitive on Windows)
     # CON, PRN, AUX, NUL
     # COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9
     # LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9
-    name_without_extension = os.path.splitext(name)[0]
-    if name_without_extension in [
+    name_without_extension = os.path.splitext(name)[0].upper()
+    reserved_names = {
         "CON",
         "PRN",
         "AUX",
@@ -48,12 +55,37 @@ def _check_that_name_is_valid_in_filesystem(name: str):
         "LPT7",
         "LPT8",
         "LPT9",
-    ]:
-        raise ValueError(f"Name {name} is reserved and cannot be used.")
+    }
+    if name_without_extension in reserved_names:
+        raise ValueError(f"Name '{name}' is a reserved Windows device name.")
 
-    # Filenames cannot end in a space or dot.
+    # Cannot end in space or dot on Windows
     if name.endswith(" ") or name.endswith("."):
-        raise ValueError(f"Name {name} cannot end in a space or dot.")
+        raise ValueError(f"Name '{name}' cannot end in a space or dot on Windows.")
+
+
+def _check_unix_filename(name: str):
+    """Validate filename for Unix-like systems (Linux, macOS)."""
+    # Only / and null byte are invalid on Unix
+    if "/" in name:
+        raise ValueError(f"Name '{name}' cannot contain '/' character.")
+
+    if "\0" in name:
+        raise ValueError(f"Name '{name}' cannot contain null byte.")
+
+
+def _check_that_name_is_valid_in_filesystem(name: str):
+    """Validate that a name is safe for filesystem use on the current platform."""
+    # Common checks: empty name or relative path indicators
+    if not name or name in (".", ".."):
+        raise ValueError(f"Name '{name}' is not valid.")
+
+    is_windows = platform.system() == "Windows"
+
+    if is_windows:
+        _check_windows_filename(name)
+    else:
+        _check_unix_filename(name)
 
 
 def _get_thread_id_from_action_context(action_context) -> str:

--- a/actions/tests/actions_tests/test_chat_files.py
+++ b/actions/tests/actions_tests/test_chat_files.py
@@ -235,8 +235,8 @@ def test_actions_with_agent_headers_call_with_invocation_context(datadir: Path):
 class TestFilenameValidationWindows:
     """Test filename validation on Windows platform."""
 
-    @patch("platform.system", return_value="Windows")
-    def test_valid_names(self, mock_platform):
+    @patch("sys.platform", new="win32")
+    def test_valid_names(self):
         """Test valid filenames that should pass on Windows."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
@@ -277,16 +277,16 @@ class TestFilenameValidationWindows:
             "asterisk",
         ],
     )
-    @patch("platform.system", return_value="Windows")
-    def test_invalid_characters(self, mock_platform, filename):
+    @patch("sys.platform", new="win32")
+    def test_invalid_characters(self, filename):
         """Test rejection of invalid characters on Windows."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
         with pytest.raises(ValueError, match="invalid characters"):
             _check_that_name_is_valid_in_filesystem(filename)
 
-    @patch("platform.system", return_value="Windows")
-    def test_control_characters(self, mock_platform):
+    @patch("sys.platform", new="win32")
+    def test_control_characters(self):
         """Test rejection of control characters on Windows."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
@@ -327,8 +327,8 @@ class TestFilenameValidationWindows:
             "filename.txt.",
         ],
     )
-    @patch("platform.system", return_value="Windows")
-    def test_invalid_names(self, mock_platform, invalid_name):
+    @patch("sys.platform", new="win32")
+    def test_invalid_names(self, invalid_name):
         """Test rejection of Windows invalid names."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
@@ -387,8 +387,8 @@ class TestFilenameValidationUnix:
             "file:with:colons.txt",
         ],
     )
-    @patch("platform.system", return_value="Linux")
-    def test_valid_unix_names(self, mock_platform, valid_name):
+    @patch("sys.platform", new="linux")
+    def test_valid_unix_names(self, valid_name):
         """Test that Unix allows characters restricted on Windows."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
@@ -401,8 +401,8 @@ class TestFilenameValidationUnix:
             "file\0name.txt",
         ],
     )
-    @patch("platform.system", return_value="Linux")
-    def test_invalid_unix_names(self, mock_platform, invalid_name):
+    @patch("sys.platform", new="linux")
+    def test_invalid_unix_names(self, invalid_name):
         """Test rejection of forward slash on Unix."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
@@ -413,32 +413,32 @@ class TestFilenameValidationUnix:
 class TestFilenameValidationEdgeCases:
     """Test edge cases for filename validation."""
 
-    @patch("platform.system", return_value="Linux")
-    def test_empty_string(self, mock_platform):
+    @patch("sys.platform", new="linux")
+    def test_empty_string(self):
         """Test rejection of empty string."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
         with pytest.raises(ValueError, match="is not valid"):
             _check_that_name_is_valid_in_filesystem("")
 
-    @patch("platform.system", return_value="Linux")
-    def test_current_directory_dot(self, mock_platform):
+    @patch("sys.platform", new="linux")
+    def test_current_directory_dot(self):
         """Test rejection of current directory reference."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
         with pytest.raises(ValueError, match="is not valid"):
             _check_that_name_is_valid_in_filesystem(".")
 
-    @patch("platform.system", return_value="Linux")
-    def test_parent_directory_dotdot(self, mock_platform):
+    @patch("sys.platform", new="linux")
+    def test_parent_directory_dotdot(self):
         """Test rejection of parent directory reference."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
         with pytest.raises(ValueError, match="is not valid"):
             _check_that_name_is_valid_in_filesystem("..")
 
-    @patch("platform.system", return_value="Linux")
-    def test_unicode_characters(self, mock_platform):
+    @patch("sys.platform", new="linux")
+    def test_unicode_characters(self):
         """Test that Unicode characters are allowed."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
@@ -452,8 +452,8 @@ class TestFilenameValidationEdgeCases:
         for name in unicode_names:
             _check_that_name_is_valid_in_filesystem(name)  # Should not raise
 
-    @patch("platform.system", return_value="Linux")
-    def test_very_long_name(self, mock_platform):
+    @patch("sys.platform", new="linux")
+    def test_very_long_name(self):
         """Test very long filename (most filesystems have limits, but we don't enforce them)."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 
@@ -461,8 +461,8 @@ class TestFilenameValidationEdgeCases:
         long_name = "a" * 300 + ".txt"
         _check_that_name_is_valid_in_filesystem(long_name)  # Should not raise
 
-    @patch("platform.system", return_value="Windows")
-    def test_windows_backslash_rejected(self, mock_platform):
+    @patch("sys.platform", new="win32")
+    def test_windows_backslash_rejected(self):
         """Test that backslash is rejected on Windows."""
         from sema4ai.actions.chat import _check_that_name_is_valid_in_filesystem
 

--- a/actions/tests/actions_tests/test_chat_files.py
+++ b/actions/tests/actions_tests/test_chat_files.py
@@ -255,17 +255,27 @@ class TestFilenameValidationWindows:
     @pytest.mark.parametrize(
         "filename",
         [
-            'report<draft>.txt',
-            'output>final.log',
-            'meeting:notes.doc',
+            "report<draft>.txt",
+            "output>final.log",
+            "meeting:notes.doc",
             'project"alpha".json',
-            'docs/readme.txt',
-            'path\\to\\file.pdf',
-            'data|backup.csv',
-            'query?results.xml',
-            'search*.txt',
+            "docs/readme.txt",
+            "path\\to\\file.pdf",
+            "data|backup.csv",
+            "query?results.xml",
+            "search*.txt",
         ],
-        ids=['less-than', 'greater-than', 'colon', 'quote', 'forward-slash', 'backslash', 'pipe', 'question', 'asterisk']
+        ids=[
+            "less-than",
+            "greater-than",
+            "colon",
+            "quote",
+            "forward-slash",
+            "backslash",
+            "pipe",
+            "question",
+            "asterisk",
+        ],
     )
     @patch("platform.system", return_value="Windows")
     def test_invalid_characters(self, mock_platform, filename):
@@ -288,11 +298,34 @@ class TestFilenameValidationWindows:
     @pytest.mark.parametrize(
         "invalid_name",
         [
-            "CON", "PRN", "AUX", "NUL",
-            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
-            "CON.txt", "PRN.doc", "LPT1.pdf", "filename.txt ", "filename.txt.",
-        ]
+            "CON",
+            "PRN",
+            "AUX",
+            "NUL",
+            "COM1",
+            "COM2",
+            "COM3",
+            "COM4",
+            "COM5",
+            "COM6",
+            "COM7",
+            "COM8",
+            "COM9",
+            "LPT1",
+            "LPT2",
+            "LPT3",
+            "LPT4",
+            "LPT5",
+            "LPT6",
+            "LPT7",
+            "LPT8",
+            "LPT9",
+            "CON.txt",
+            "PRN.doc",
+            "LPT1.pdf",
+            "filename.txt ",
+            "filename.txt.",
+        ],
     )
     @patch("platform.system", return_value="Windows")
     def test_invalid_names(self, mock_platform, invalid_name):
@@ -352,7 +385,7 @@ class TestFilenameValidationUnix:
             "LPT8",
             "LPT9",
             "file:with:colons.txt",
-        ]
+        ],
     )
     @patch("platform.system", return_value="Linux")
     def test_valid_unix_names(self, mock_platform, valid_name):
@@ -361,13 +394,12 @@ class TestFilenameValidationUnix:
 
         _check_that_name_is_valid_in_filesystem(valid_name)  # Should not raise
 
-
     @pytest.mark.parametrize(
         "invalid_name",
         [
             "file/name.txt",
             "file\0name.txt",
-        ]
+        ],
     )
     @patch("platform.system", return_value="Linux")
     def test_invalid_unix_names(self, mock_platform, invalid_name):


### PR DESCRIPTION
Windows disallows certain characters in file names that Unix does not. This is required because the AgentServer uses the local filesystem for file storage in Studio. However, we should not over-enforce this limit as it creates a situation where ACE/SPAR/etc then cannot store files with names that the OS does allow.

This change separates the `_check_that_name_is_valid_in_filesystem` function into unix and windows equivalent functions, delegating to the appropriate one depending on platform.