### PR TITLE
Copy PackageExcludeHandler into commons

### DIFF
--- a/common/docs/CHANGELOG.md
+++ b/common/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-01-08
+
+- Copy PackageExcludeHandler into commons and add a new interface to it for filtering relative paths
+
 ## 0.2.2 - 2025-12-17
 
 - CVE fixes

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-common"
-version = "0.2.2"
+version = "0.3.0"
 description = "Sema4AI Common"
 authors = ["Sema4.ai Engineering <engineering@sema4.ai>"]
 readme = "README.md"

--- a/common/src/sema4ai/common/__init__.py
+++ b/common/src/sema4ai/common/__init__.py
@@ -8,5 +8,5 @@ Each module should be a single utility (thus, sema4ai.common doesn't directly
 contain anything).
 """
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 version_info = [int(x) for x in __version__.split(".")]

--- a/common/src/sema4ai/common/package_exclude.py
+++ b/common/src/sema4ai/common/package_exclude.py
@@ -1,0 +1,169 @@
+import fnmatch
+import glob
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+
+class ExclusionPatternError(ValueError):
+    """Raised when the exclusion patterns are invalid."""
+
+
+class PackageExcludeHandler:
+    """
+    Handles exclusion patterns for packaging.
+    """
+
+    def __init__(self) -> None:
+        self.exclude_patterns: list[str] = []
+
+    def fill_exclude_patterns(self, exclude_list: Any) -> None:
+        """
+        Args:
+            exclude_list: List of strings with exclusion patterns.
+                Note that we accept "Any" because the validation is done
+                in this function (as it usually comes from untrusted sources).
+        """
+
+        if exclude_list:
+            if not isinstance(exclude_list, list):
+                raise ExclusionPatternError(
+                    "Expected exclude patterns to be list[str]."
+                )
+
+            for pat in exclude_list:
+                if not isinstance(pat, str):
+                    raise ExclusionPatternError(
+                        "Expected exclude patterns to be list[str]. Found item: "
+                        f"{pat} ({type(pat)}) in list."
+                    )
+
+                if pat.startswith("./"):
+                    # If the user did './b/c', we have to start the match from
+                    # the current path.
+                    pat = pat[2:]
+                elif pat.startswith("/"):
+                    # If the user did '/b/c', we have to start the match from
+                    # the root.
+                    pat = pat[1:]
+                elif not pat.startswith("**"):
+                    # If the user did not anchor the pattern, make it available to
+                    # be matched anywhere (i.e.: *.pyc must match .pyc files anywhere).
+                    pat = f"**/{pat}"
+
+                self.exclude_patterns.append(pat)
+
+    def collect_files_excluding_patterns(
+        self, root_dir: Path
+    ) -> Iterator[tuple[Path, str]]:
+        """
+        Collects all files within a directory, excluding those that match any of the
+        specified exclusion patterns.
+        """
+        return _collect_files_excluding_patterns(root_dir, self.exclude_patterns)
+
+    def filter_relative_paths_excluding_patterns(self, paths: list[str]) -> list[str]:
+        """
+        Filter a list of relative paths, excluding those that match any of the
+        specified exclusion patterns.
+        """
+        filtered_paths: list[str] = []
+        for path in paths:
+            if not _path_is_excluded(path, self.exclude_patterns):
+                filtered_paths.append(path)
+        return filtered_paths
+
+
+def _check_matches(patterns, paths):
+    if not patterns and not paths:
+        # Matched to the end.
+        return True
+
+    if (not patterns and paths) or (patterns and not paths):
+        return False
+
+    pattern = patterns[0]
+    path = paths[0]
+
+    if not glob.has_magic(pattern):
+        if pattern != path:
+            return False
+
+    elif pattern == "**":
+        if len(patterns) == 1:
+            return True  # if ** is the last one it matches anything to the right.
+
+        for i in range(len(paths)):
+            # Recursively check the remaining patterns as the
+            # current pattern could match any number of paths.
+            if _check_matches(patterns[1:], paths[i:]):
+                return True
+
+    elif not fnmatch.fnmatch(path, pattern):
+        # Current part doesn't match.
+        return False
+
+    return _check_matches(patterns[1:], paths[1:])
+
+
+def _glob_matches_path(path, pattern, sep=os.sep, altsep=os.altsep):
+    if altsep:
+        pattern = pattern.replace(altsep, sep)
+        path = path.replace(altsep, sep)
+
+    patterns = pattern.split(sep)
+    paths = path.split(sep)
+    if paths:
+        if paths[0] == "":
+            paths = paths[1:]
+    if patterns:
+        if patterns[0] == "":
+            patterns = patterns[1:]
+
+    return _check_matches(patterns, paths)
+
+
+def _collect_files_excluding_patterns(
+    root_dir: Path, exclusion_patterns: list[str]
+) -> Iterator[tuple[Path, str]]:
+    """
+    Collects all files within a directory, excluding those that match any of the
+    specified exclusion patterns.
+
+    Args:
+        root_dir (str): The root directory to traverse.
+        exclusion_patterns (list): A list of fnmatch patterns to exclude.
+
+    Returns:
+        An iterator over the full paths and the relative paths (str) found.
+    """
+
+    for path in root_dir.rglob("*"):  # Use rglob for recursive iteration
+        if path.is_file():
+            relative_path_str = str(path.relative_to(root_dir))
+
+            if not _path_is_excluded(relative_path_str, exclusion_patterns):
+                yield path, relative_path_str
+
+
+def _normalize_pattern(pattern: str) -> str:
+    while pattern.endswith(("/", "\\")):
+        pattern = pattern[:-1]
+    return pattern
+
+
+def _path_is_excluded(path: str, exclusion_patterns: list[str]) -> bool:
+    if not exclusion_patterns:
+        return False
+
+    normalized_path = path.replace("\\", "/")
+    path_parts = [part for part in normalized_path.split("/") if part]
+    ancestors = ["/".join(path_parts[:idx]) for idx in range(1, len(path_parts))]
+    candidates = [normalized_path, *ancestors]
+
+    for pattern in exclusion_patterns:
+        normalized_pattern = _normalize_pattern(pattern)
+        for candidate in candidates:
+            if _glob_matches_path(candidate, normalized_pattern):
+                return True
+    return False

--- a/common/src/sema4ai/common/package_exclude.py
+++ b/common/src/sema4ai/common/package_exclude.py
@@ -157,13 +157,8 @@ def _path_is_excluded(path: str, exclusion_patterns: list[str]) -> bool:
         return False
 
     normalized_path = path.replace("\\", "/")
-    path_parts = [part for part in normalized_path.split("/") if part]
-    ancestors = ["/".join(path_parts[:idx]) for idx in range(1, len(path_parts))]
-    candidates = [normalized_path, *ancestors]
-
     for pattern in exclusion_patterns:
         normalized_pattern = _normalize_pattern(pattern)
-        for candidate in candidates:
-            if _glob_matches_path(candidate, normalized_pattern):
-                return True
+        if _glob_matches_path(normalized_path, normalized_pattern):
+            return True
     return False

--- a/common/tests/sema4ai_common_tests/test_package_exclude.py
+++ b/common/tests/sema4ai_common_tests/test_package_exclude.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from sema4ai.common.package_exclude import ExclusionPatternError, PackageExcludeHandler
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x", encoding="utf-8")
+
+
+def _normalize_relpath(path: str) -> str:
+    normalized = path.replace(os.sep, "/")
+    if os.altsep:
+        normalized = normalized.replace(os.altsep, "/")
+    return normalized
+
+
+def test_collect_files_excluding_patterns(tmp_path: Path) -> None:
+    _touch(tmp_path / "ignore" / "some.txt")
+    _touch(tmp_path / "another" / "not_ok.txt")
+    _touch(tmp_path / "another" / "ok.txt")
+    _touch(tmp_path / "another" / "no.foo")
+    _touch(tmp_path / "folder" / "dont_ignore")
+    _touch(tmp_path / "folder" / "ignore_only_at_root")
+    _touch(tmp_path / "hello_action.py")
+    _touch(tmp_path / "package.yaml")
+    _touch(tmp_path / "ignore_only_at_root")
+
+    handler = PackageExcludeHandler()
+    handler.fill_exclude_patterns(
+        ["ignore/**", "not_ok.txt", "*.foo", "./ignore_only_at_root"]
+    )
+
+    found = {
+        _normalize_relpath(relpath)
+        for _, relpath in handler.collect_files_excluding_patterns(tmp_path)
+    }
+
+    assert found == {
+        "another/ok.txt",
+        "folder/dont_ignore",
+        "folder/ignore_only_at_root",
+        "hello_action.py",
+        "package.yaml",
+    }
+
+
+def test_invalid_exclusion_patterns() -> None:
+    handler = PackageExcludeHandler()
+
+    with pytest.raises(ExclusionPatternError):
+        handler.fill_exclude_patterns("not-a-list")
+
+    with pytest.raises(ExclusionPatternError):
+        handler.fill_exclude_patterns([123])
+
+
+def test_filter_relative_paths_excluding_patterns() -> None:
+    handler = PackageExcludeHandler()
+    handler.fill_exclude_patterns(
+        ["ignore/**", "not_ok.txt", "*.foo", "./ignore_only_at_root", "/root_only.txt"]
+    )
+
+    paths = [
+        "ignore/some.txt",
+        "another/not_ok.txt",
+        "another/ok.txt",
+        "another/no.foo",
+        "folder/dont_ignore",
+        "folder/ignore_only_at_root",
+        "hello_action.py",
+        "package.yaml",
+        "ignore_only_at_root",
+        "root_only.txt",
+        "nested/root_only.txt",
+        "win\\path\\no.foo",
+    ]
+
+    assert handler.filter_relative_paths_excluding_patterns(paths) == [
+        "another/ok.txt",
+        "folder/dont_ignore",
+        "folder/ignore_only_at_root",
+        "hello_action.py",
+        "package.yaml",
+        "nested/root_only.txt",
+    ]

--- a/common/tests/sema4ai_common_tests/test_package_exclude.py
+++ b/common/tests/sema4ai_common_tests/test_package_exclude.py
@@ -23,6 +23,7 @@ def test_collect_files_excluding_patterns(tmp_path: Path) -> None:
     _touch(tmp_path / "another" / "not_ok.txt")
     _touch(tmp_path / "another" / "ok.txt")
     _touch(tmp_path / "another" / "no.foo")
+    _touch(tmp_path / "foo" / "keep.txt")
     _touch(tmp_path / "folder" / "dont_ignore")
     _touch(tmp_path / "folder" / "ignore_only_at_root")
     _touch(tmp_path / "hello_action.py")
@@ -31,7 +32,7 @@ def test_collect_files_excluding_patterns(tmp_path: Path) -> None:
 
     handler = PackageExcludeHandler()
     handler.fill_exclude_patterns(
-        ["ignore/**", "not_ok.txt", "*.foo", "./ignore_only_at_root"]
+        ["ignore/**", "not_ok.txt", "*.foo", "./ignore_only_at_root", "foo"]
     )
 
     found = {
@@ -41,6 +42,7 @@ def test_collect_files_excluding_patterns(tmp_path: Path) -> None:
 
     assert found == {
         "another/ok.txt",
+        "foo/keep.txt",
         "folder/dont_ignore",
         "folder/ignore_only_at_root",
         "hello_action.py",
@@ -61,7 +63,14 @@ def test_invalid_exclusion_patterns() -> None:
 def test_filter_relative_paths_excluding_patterns() -> None:
     handler = PackageExcludeHandler()
     handler.fill_exclude_patterns(
-        ["ignore/**", "not_ok.txt", "*.foo", "./ignore_only_at_root", "/root_only.txt"]
+        [
+            "ignore/**",
+            "not_ok.txt",
+            "*.foo",
+            "./ignore_only_at_root",
+            "/root_only.txt",
+            "foo",
+        ]
     )
 
     paths = [
@@ -69,6 +78,8 @@ def test_filter_relative_paths_excluding_patterns() -> None:
         "another/not_ok.txt",
         "another/ok.txt",
         "another/no.foo",
+        "foo",
+        "foo/keep.txt",
         "folder/dont_ignore",
         "folder/ignore_only_at_root",
         "hello_action.py",
@@ -81,6 +92,7 @@ def test_filter_relative_paths_excluding_patterns() -> None:
 
     assert handler.filter_relative_paths_excluding_patterns(paths) == [
         "another/ok.txt",
+        "foo/keep.txt",
         "folder/dont_ignore",
         "folder/ignore_only_at_root",
         "hello_action.py",

--- a/devutils/src/devutils/invoke_utils.py
+++ b/devutils/src/devutils/invoke_utils.py
@@ -176,7 +176,14 @@ def build_common_tasks(
     DIST = root / "dist"
     CONDA_ENV_NAME = package_name.replace(".", "-").replace("_", "-")
     TARGETS = " ".join(source_directories)
-    RUFF_ARGS = f"--config {ROOT / 'ruff.toml'} {ruff_format_arguments}".strip()
+    def _quote_if_needed(value: str | Path) -> str:
+        text = str(value)
+        if any(ch.isspace() for ch in text):
+            return f'"{text}"'
+        return text
+
+    ruff_config = _quote_if_needed(ROOT / "ruff.toml")
+    RUFF_ARGS = f"--config {ruff_config} {ruff_format_arguments}".strip()
 
     def run(
         ctx,


### PR DESCRIPTION
Copy the PackageExcludeHandler from action server to common package so it can also be used in the Agent Server when building an agent package.

Added a new interface to PackageExcludeHandler to filter a list of file names.