### PR TITLE
Add code for authenticating against Agent Server

### DIFF
--- a/actions/src/sema4ai/actions/_callback.py
+++ b/actions/src/sema4ai/actions/_callback.py
@@ -1,6 +1,46 @@
 from logging import getLogger
+from urllib.parse import urlparse
+
+from sema4ai.actions._action import get_current_requests_contexts
 
 logger = getLogger(__name__)
+
+
+def get_request_header(header_name: str) -> str | None:
+    request_contexts = get_current_requests_contexts()
+    if request_contexts is None or request_contexts.request is None:
+        return None
+    value = request_contexts.request.headers.get(header_name)
+    if value:
+        return str(value).strip() or None
+    return None
+
+
+def normalize_callback_base_url(
+    callback_base_url: str, required_suffix: str | None = None
+) -> str:
+    normalized = callback_base_url.rstrip("/")
+    if not required_suffix:
+        return normalized
+
+    required_suffix = required_suffix.rstrip("/")
+    if normalized.endswith(required_suffix):
+        return f"{normalized}/"
+    return f"{normalized}{required_suffix}/"
+
+
+def should_propagate_auth_header(target_url: str, base_url: str) -> bool:
+    parsed_target = urlparse(target_url)
+    parsed_base = urlparse(base_url)
+
+    if (
+        parsed_target.scheme in {"http", "https"}
+        and parsed_base.netloc
+        and parsed_target.netloc
+        and parsed_target.netloc != parsed_base.netloc
+    ):
+        return False
+    return True
 
 
 class OnExitContextManager:

--- a/actions/src/sema4ai/actions/_callback.py
+++ b/actions/src/sema4ai/actions/_callback.py
@@ -7,6 +7,8 @@ logger = getLogger(__name__)
 
 
 def get_request_header(header_name: str) -> str | None:
+    # MCP hosts are expected to bind RequestContexts for each tool request.
+    # Callback headers are always read from that bound request context.
     request_contexts = get_current_requests_contexts()
     if request_contexts is None or request_contexts.request is None:
         return None
@@ -19,6 +21,8 @@ def get_request_header(header_name: str) -> str | None:
 def normalize_callback_base_url(
     callback_base_url: str, required_suffix: str | None = None
 ) -> str:
+    # Callback base URLs may arrive with/without trailing slash and suffix.
+    # Normalize once so callers can safely append endpoint paths.
     normalized = callback_base_url.rstrip("/")
     if not required_suffix:
         return normalized
@@ -30,6 +34,8 @@ def normalize_callback_base_url(
 
 
 def should_propagate_auth_header(target_url: str, base_url: str) -> bool:
+    # Forward callback auth only to same-host Agent Server/Workroom endpoints.
+    # Example: don't forward callback auth to external presigned storage URLs.
     parsed_target = urlparse(target_url)
     parsed_base = urlparse(base_url)
 

--- a/actions/src/sema4ai/actions/agent/_client.py
+++ b/actions/src/sema4ai/actions/agent/_client.py
@@ -8,6 +8,11 @@ from urllib.parse import urlencode, urljoin, urlparse
 import sema4ai_http
 
 from sema4ai.actions._action import get_x_action_invocation_context
+from sema4ai.actions._callback import (
+    get_request_header,
+    normalize_callback_base_url,
+    should_propagate_auth_header,
+)
 from sema4ai.actions._response import ActionError
 
 log = logging.getLogger(__name__)
@@ -30,6 +35,9 @@ class _AgentAPIClient:
 
         log.info(f"API URL: {self.api_url}")
 
+    def _get_callback_auth_header(self) -> str | None:
+        return get_request_header("x-ags-callback")
+
     def _get_api_url(self) -> str:
         """Determine the correct API URL by checking environment variable or agent-server.pid file
         and testing API availability.
@@ -40,6 +48,10 @@ class _AgentAPIClient:
         Raises:
             AgentApiClientException: If no API server is responding
         """
+        callback_base_url = get_request_header("x-ags-base-url")
+        if callback_base_url:
+            return normalize_callback_base_url(callback_base_url, "/api/v2")
+
         # Try to get URL from environment variable first
         api_url = self._try_get_url_from_environment()
         if api_url:
@@ -160,6 +172,9 @@ class _AgentAPIClient:
         request_headers[
             "x-action-invocation-context"
         ] = get_x_action_invocation_context()
+        callback_auth = self._get_callback_auth_header()
+        if callback_auth and should_propagate_auth_header(url, self.api_url):
+            request_headers["Authorization"] = callback_auth
 
         if query_params:
             url = f"{url}?{urlencode(query_params)}"

--- a/actions/src/sema4ai/actions/agent/_client.py
+++ b/actions/src/sema4ai/actions/agent/_client.py
@@ -6,7 +6,6 @@ from copy import copy
 from urllib.parse import urlencode, urljoin, urlparse
 
 import sema4ai_http
-
 from sema4ai.actions._action import get_x_action_invocation_context
 from sema4ai.actions._callback import (
     get_request_header,
@@ -48,6 +47,7 @@ class _AgentAPIClient:
         Raises:
             AgentApiClientException: If no API server is responding
         """
+        # In MCP callback flows, API base URL is request-derived from headers.
         callback_base_url = get_request_header("x-ags-base-url")
         if callback_base_url:
             return normalize_callback_base_url(callback_base_url, "/api/v2")
@@ -172,6 +172,7 @@ class _AgentAPIClient:
         request_headers[
             "x-action-invocation-context"
         ] = get_x_action_invocation_context()
+        # Add callback auth conditionally
         callback_auth = self._get_callback_auth_header()
         if callback_auth and should_propagate_auth_header(url, self.api_url):
             request_headers["Authorization"] = callback_auth

--- a/actions/src/sema4ai/actions/chat/_client.py
+++ b/actions/src/sema4ai/actions/chat/_client.py
@@ -1,4 +1,9 @@
 from sema4ai.actions._action import get_x_action_invocation_context
+from sema4ai.actions._callback import (
+    get_request_header,
+    normalize_callback_base_url,
+    should_propagate_auth_header,
+)
 
 FileId = str
 
@@ -16,6 +21,13 @@ class _Client:
         import urllib
 
         from sema4ai.actions import _uris
+
+        if not file_management_url_value:
+            callback_base_url = get_request_header("x-ags-base-url")
+            if callback_base_url:
+                file_management_url_value = normalize_callback_base_url(
+                    callback_base_url
+                )
 
         if not file_management_url_value:
             file_management_url_value = os.environ.get(
@@ -45,6 +57,17 @@ files will be stored to or accessed from."""
 
     def is_local_mode(self) -> bool:
         return self._is_local_mode
+
+    def _get_file_management_auth_header(self) -> str | None:
+        return get_request_header("x-ags-callback")
+
+    def _maybe_add_auth_header(self, url: str, headers: dict[str, str]) -> None:
+        auth_header = self._get_file_management_auth_header()
+        if not auth_header:
+            return
+        if not should_propagate_auth_header(url, self._url):
+            return
+        headers["Authorization"] = auth_header
 
     def get_bytes(self, filename: str, thread_id: str) -> bytes:
         import os.path
@@ -80,6 +103,7 @@ files will be stored to or accessed from."""
                 "Content-Type": "application/json",
                 "x-action-invocation-context": get_x_action_invocation_context(),
             }
+            self._maybe_add_auth_header(url, headers)
 
             # Send the initial request
             response = sema4ai_http.get(
@@ -102,7 +126,9 @@ files will be stored to or accessed from."""
                 p = Path(_uris.to_fs_path(file_url))
                 return p.read_bytes()
             else:
-                response = sema4ai_http.get(file_url)
+                file_headers: dict[str, str] = {}
+                self._maybe_add_auth_header(file_url, file_headers)
+                response = sema4ai_http.get(file_url, headers=file_headers or None)
                 self._raise_for_status(
                     f"Failed to get file {filename} from {file_url}. ",
                     response,
@@ -168,6 +194,7 @@ files will be stored to or accessed from."""
                 "Content-Type": "application/json",
                 "x-action-invocation-context": get_x_action_invocation_context(),
             }
+            self._maybe_add_auth_header(url, headers)
             data = json.dumps(
                 {"file_name": filename, "file_size": len(content)}
             ).encode("utf-8")
@@ -224,6 +251,7 @@ files will be stored to or accessed from."""
                 "Content-Type": "application/json",
                 "x-action-invocation-context": get_x_action_invocation_context(),
             }
+            self._maybe_add_auth_header(url, headers)
             data = json.dumps({"file_ref": file_ref, "file_id": file_id}).encode(
                 "utf-8"
             )
@@ -275,6 +303,7 @@ files will be stored to or accessed from."""
                 "Content-Type": "application/json",
                 "x-action-invocation-context": get_x_action_invocation_context(),
             }
+            self._maybe_add_auth_header(url, headers)
 
             response = sema4ai_http.get(url, headers=headers)
             self._raise_for_status(

--- a/actions/src/sema4ai/actions/chat/_client.py
+++ b/actions/src/sema4ai/actions/chat/_client.py
@@ -23,6 +23,7 @@ class _Client:
         from sema4ai.actions import _uris
 
         if not file_management_url_value:
+            # Prefer request-scoped callback URL from Agent Server when available.
             callback_base_url = get_request_header("x-ags-base-url")
             if callback_base_url:
                 file_management_url_value = normalize_callback_base_url(
@@ -59,6 +60,7 @@ files will be stored to or accessed from."""
         return self._is_local_mode
 
     def _get_file_management_auth_header(self) -> str | None:
+        # Callback token is forwarded by Agent Server on MCP requests.
         return get_request_header("x-ags-callback")
 
     def _maybe_add_auth_header(self, url: str, headers: dict[str, str]) -> None:
@@ -103,6 +105,7 @@ files will be stored to or accessed from."""
                 "Content-Type": "application/json",
                 "x-action-invocation-context": get_x_action_invocation_context(),
             }
+                # Add auth header conditionally
             self._maybe_add_auth_header(url, headers)
 
             # Send the initial request
@@ -194,6 +197,7 @@ files will be stored to or accessed from."""
                 "Content-Type": "application/json",
                 "x-action-invocation-context": get_x_action_invocation_context(),
             }
+            # Add auth header conditionally
             self._maybe_add_auth_header(url, headers)
             data = json.dumps(
                 {"file_name": filename, "file_size": len(content)}
@@ -251,6 +255,7 @@ files will be stored to or accessed from."""
                 "Content-Type": "application/json",
                 "x-action-invocation-context": get_x_action_invocation_context(),
             }
+            # Add auth header conditionally
             self._maybe_add_auth_header(url, headers)
             data = json.dumps({"file_ref": file_ref, "file_id": file_id}).encode(
                 "utf-8"

--- a/actions/tests/actions_tests/test_callback_headers.py
+++ b/actions/tests/actions_tests/test_callback_headers.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sema4ai.actions._action import set_current_requests_contexts
+from sema4ai.actions._action_context import RequestContexts
+from sema4ai.actions._callback import (
+    get_request_header,
+    normalize_callback_base_url,
+    should_propagate_auth_header,
+)
+from sema4ai.actions._request import Request
+
+
+def _bind_request_context(headers: dict[str, str]) -> None:
+    request = Request.model_validate({"headers": headers})
+    set_current_requests_contexts(RequestContexts(request))
+
+
+@pytest.fixture(autouse=True)
+def _clear_request_context():
+    set_current_requests_contexts(None)
+    yield
+    set_current_requests_contexts(None)
+
+
+def test_get_request_header_from_bound_context() -> None:
+    _bind_request_context({"x-ags-base-url": "http://localhost:8001/api/v2"})
+    assert get_request_header("x-ags-base-url") == "http://localhost:8001/api/v2"
+    assert get_request_header("x-missing") is None
+
+
+def test_normalize_callback_base_url() -> None:
+    assert normalize_callback_base_url("http://localhost:8001/api/v2/") == "http://localhost:8001/api/v2"
+    assert (
+        normalize_callback_base_url("http://localhost:8001/tenants/spar/agents", "/api/v2")
+        == "http://localhost:8001/tenants/spar/agents/api/v2/"
+    )
+    assert (
+        normalize_callback_base_url("http://localhost:8001/api/v2", "/api/v2")
+        == "http://localhost:8001/api/v2/"
+    )
+
+
+def test_should_propagate_auth_header() -> None:
+    assert (
+        should_propagate_auth_header(
+            "http://localhost:8001/tenants/spar/agents/api/v2/threads/t/files",
+            "http://localhost:8001/tenants/spar/agents/api/v2",
+        )
+        is True
+    )
+    assert (
+        should_propagate_auth_header(
+            "https://storage.googleapis.com/presigned-url",
+            "http://localhost:8001/tenants/spar/agents/api/v2",
+        )
+        is False
+    )
+
+
+@dataclass
+class _ChatResponse:
+    status: int
+    data: bytes
+    _json_data: dict
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.mark.parametrize(
+    ("download_url", "expects_auth_on_download"),
+    [
+        ("http://localhost:8001/tenants/spar/agents/api/v2/download", True),
+        ("https://storage.example.com/presigned-get", False),
+    ],
+)
+def test_chat_client_callback_auth_propagation(
+    monkeypatch, download_url: str, expects_auth_on_download: bool
+) -> None:
+    from sema4ai.actions.chat import _client
+    import sema4ai_http
+
+    _bind_request_context(
+        {
+            "x-ags-base-url": "http://localhost:8001/tenants/spar/agents/api/v2",
+            "x-ags-callback": "Bearer callback-token",
+            "x-action-invocation-context": "e30=",
+        }
+    )
+
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    def fake_get(url, *args, **kwargs):
+        headers = kwargs.get("headers")
+        calls.append((url, headers))
+        if url.endswith("/file-by-ref"):
+            return _ChatResponse(
+                status=200,
+                data=b"",
+                _json_data={"file_url": download_url},
+            )
+        return _ChatResponse(status=200, data=b"downloaded", _json_data={})
+
+    monkeypatch.setattr(sema4ai_http, "get", fake_get)
+
+    client = _client._Client()
+    assert client.get_bytes("file-ref", "thread-1") == b"downloaded"
+
+    # Initial callback call (to Agent Server/Workroom) always gets callback auth.
+    assert calls[0][1] is not None
+    assert calls[0][1].get("Authorization") == "Bearer callback-token"
+    if expects_auth_on_download:
+        assert calls[1][1] is not None
+        assert calls[1][1].get("Authorization") == "Bearer callback-token"
+    else:
+        assert calls[1][1] in (None, {})
+
+
+@dataclass
+class _AgentResponse:
+    status_code: int
+    text: str = ""
+    reason: str = ""
+
+
+def _patch_agent_get_capture(monkeypatch) -> dict[str, str]:
+    import sema4ai_http
+
+    captured: dict[str, str] = {}
+
+    def fake_get(url, *args, **kwargs):
+        headers = kwargs.get("headers", {})
+        captured.update(headers)
+        return _AgentResponse(status_code=200)
+
+    monkeypatch.setattr(sema4ai_http, "get", fake_get)
+    return captured
+
+
+@pytest.mark.parametrize(
+    ("request_path", "expects_auth"),
+    [
+        ("ok", True),
+        ("https://example.com/path", False),
+    ],
+)
+def test_agent_client_callback_auth_propagation(
+    monkeypatch, request_path: str, expects_auth: bool
+) -> None:
+    from sema4ai.actions.agent._client import _AgentAPIClient
+
+    _bind_request_context(
+        {
+            "x-ags-base-url": "http://localhost:8001/tenants/spar/agents",
+            "x-ags-callback": "Bearer callback-token",
+            "x-action-invocation-context": "e30=",
+        }
+    )
+
+    captured = _patch_agent_get_capture(monkeypatch)
+
+    client = _AgentAPIClient()
+    assert client.api_url == "http://localhost:8001/tenants/spar/agents/api/v2/"
+    client.request(request_path, method="GET")
+    if expects_auth:
+        assert captured.get("Authorization") == "Bearer callback-token"
+    else:
+        assert "Authorization" not in captured


### PR DESCRIPTION
### Background 

Add Agent Server callback header support to `sema4ai.actions` chat/agent clients.

This:
- Enables MCP tool callbacks to Agent Server without requiring MCP-specific env vars for callback URLs/auth.
- Uses incoming Moonraker-provided headers as the callback contract.

### Changes

- Add request-header helpers in `actions/_callback.py` to read callback headers from bound request context.
- Update `chat/_client.py` to:
  - derive file-management base URL from `x-ags-base-url`
  - use `x-ags-callback` as callback `Authorization`
  - propagate callback auth only when target is same-host.
- Update `agent/_client.py` to:
  - derive API base URL from `x-ags-base-url` (normalized to `/api/v2`)
  - use `x-ags-callback` for callback auth on same-host requests.

### Notes

#### Assumptions
- MCP host binds `RequestContexts` for each tool request so `get_current_requests_contexts().request.headers` is populated.
- Incoming MCP requests include:
  - `x-ags-base-url`
  - `x-ags-callback`
  - `x-action-invocation-context` (or equivalent thread context for chat flows).
- Callback targets sharing host/netloc with base URL are trusted internal endpoints.

#### Legacy behaviour
- Env/pid fallback behavior remains for legacy/non-callback usage.
- Auth header is intentionally not propagated to external presigned URLs (different host).