### PR TITLE
Write server-info.json to data dir on startup

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Write `server-info.json` to the data directory on startup with runtime details (PID, port, address, URL, data dir, TLS config, version, child PIDs). The file is removed on shutdown.
+
 ## 3.0.0 - 2026-01-08
 
 - Removed support for macos x86_64 (only macos arm64 is supported).

--- a/action_server/src/sema4ai/action_server/_cli_impl.py
+++ b/action_server/src/sema4ai/action_server/_cli_impl.py
@@ -999,6 +999,9 @@ information from this datadir.
                         log.critical("Exiting action server...")
                         return 1
                     finally:
+                        from ._server import _cleanup_server_info_file
+
+                        _cleanup_server_info_file(settings.datadir)
                         kill_subprocesses()
                     return 0
 

--- a/action_server/src/sema4ai/action_server/_server.py
+++ b/action_server/src/sema4ai/action_server/_server.py
@@ -69,7 +69,6 @@ def _write_server_info_file(settings, host: str, port: int, url: str) -> None:
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(info, f, indent=2)
-                f.write("\n")
             os.replace(tmp_path, str(target))
         except BaseException:
             try:
@@ -421,6 +420,8 @@ def start_server(
         settings = get_settings()
         settings.base_url = url
 
+        _write_server_info_file(settings, host, port, url)
+
         log.info(
             colored("\n  ⚡️ Local MCP endpoint: ", "green", attrs=["bold"])
             + colored(f"{url}/mcp", "light_blue")
@@ -448,8 +449,6 @@ def start_server(
                         colored("  🔑 API Authorization Bearer key: ", attrs=["bold"])
                         + f"{api_key}\n"
                     )
-
-        _write_server_info_file(settings, host, port, url)
 
     @asynccontextmanager
     async def _expose_and_shutdown(app: FastAPI):

--- a/action_server/src/sema4ai/action_server/_server.py
+++ b/action_server/src/sema4ai/action_server/_server.py
@@ -24,6 +24,74 @@ class _LoopHolder:
     loop: Optional["AbstractEventLoop"] = None
 
 
+SERVER_INFO_FILENAME = "server-info.json"
+
+
+def _write_server_info_file(settings, host: str, port: int, url: str) -> None:
+    """Write runtime info JSON into the data directory.
+
+    Written atomically (temp file + rename) so consumers never see partial
+    content.  Errors are logged but do not prevent the server from running.
+    """
+    import json
+    import tempfile
+
+    import psutil
+
+    from . import __version__
+
+    try:
+        child_pids = [
+            c.pid for c in psutil.Process(os.getpid()).children(recursive=False)
+        ]
+    except Exception:
+        log.exception("Failed to collect child PIDs")
+        child_pids = []
+
+    info = {
+        "pid": os.getpid(),
+        "port": port,
+        "address": host,
+        "url": url,
+        "datadir": str(settings.datadir),
+        "use_https": settings.use_https,
+        "ssl_certfile": settings.ssl_certfile if settings.use_https else None,
+        "ssl_keyfile": settings.ssl_keyfile if settings.use_https else None,
+        "version": __version__,
+        "child_pids": child_pids,
+    }
+
+    target = settings.datadir / SERVER_INFO_FILENAME
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(settings.datadir), suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(info, f, indent=2)
+                f.write("\n")
+            os.replace(tmp_path, str(target))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        log.exception("Failed to write server info file: %s", target)
+        return
+
+    log.info("Server info written to: %s", target)
+
+
+def _cleanup_server_info_file(datadir) -> None:
+    """Remove the server info file on shutdown."""
+    try:
+        (datadir / SERVER_INFO_FILENAME).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def start_server(
     start_args: ArgumentsNamespaceStart,
     api_key: str | None,
@@ -380,6 +448,8 @@ def start_server(
                         colored("  🔑 API Authorization Bearer key: ", attrs=["bold"])
                         + f"{api_key}\n"
                     )
+
+        _write_server_info_file(settings, host, port, url)
 
     @asynccontextmanager
     async def _expose_and_shutdown(app: FastAPI):

--- a/action_server/src/sema4ai/action_server/_server.py
+++ b/action_server/src/sema4ai/action_server/_server.py
@@ -63,9 +63,7 @@ def _write_server_info_file(settings, host: str, port: int, url: str) -> None:
 
     target = settings.datadir / SERVER_INFO_FILENAME
     try:
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(settings.datadir), suffix=".tmp"
-        )
+        fd, tmp_path = tempfile.mkstemp(dir=str(settings.datadir), suffix=".tmp")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(info, f, indent=2)


### PR DESCRIPTION
## Motivation

By writing a structured `server-info.json` to the data directory on startup, consumers like Studio can reliably discover the server's runtime details (port, PID, child PIDs, etc.) without resorting to log parsing.

## Summary

- The action server now writes a `server-info.json` file into the data directory once the server has fully started (port bound, process pool warmed up)
- Contains: PID, port, address, URL, data dir, TLS config, version, and child PIDs
- Written atomically (temp file + `os.replace`) so consumers never see partial content
- Cleaned up automatically on shutdown; write failures are logged but don't prevent the server from running

## Test plan

- [x] Start the action server and verify `server-info.json` appears in the data directory
- [x] Verify the JSON content is correct (PID matches, port matches, child PIDs are present)
- [x] Stop the server and verify the file is removed
- [x] Test with `--port=0` to ensure the resolved port is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)