### PR TITLE
Release Action Server 3.1.1

### DIFF
--- a/.github/workflows/_gen_workflows.py
+++ b/.github/workflows/_gen_workflows.py
@@ -1028,6 +1028,7 @@ class ActionServerManylinuxRelease(BaseWorkflow):
             "runs-on": "${{ matrix.os }}",
             "strategy": {
                 "fail-fast": self.fail_fast,
+                "max-parallel": 1,
                 "matrix": self.matrix_cibuildwheel(self.minimum_python_version),
             },
         }

--- a/.github/workflows/action_server_manylinux_release.yml
+++ b/.github/workflows/action_server_manylinux_release.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
+      max-parallel: 1
       matrix:
         os:
         - ubuntu-22.04

--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.1.1 - 2026-03-09
+
+- Run manylinux wheel builds sequentially to avoid GitHub rate limiting during virtualenv download.
+
 ## 3.1.0 - 2026-03-09
 
 - Write `server-info.json` to the data directory on startup with runtime details (PID, port, address, URL, data dir, TLS config, version, child PIDs). The file is removed on shutdown.

--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.1.0 - 2026-03-09
+
 - Write `server-info.json` to the data directory on startup with runtime details (PID, port, address, URL, data dir, TLS config, version, child PIDs). The file is removed on shutdown.
 
 ## 3.0.0 - 2026-01-08

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-action-server"
-version = "3.0.0"
+version = "3.1.0"
 description = """Sema4AI Action Server"""
 authors = [
 	"Sema4.ai, Inc. <dev@sema4.ai>",

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-action-server"
-version = "3.1.0"
+version = "3.1.1"
 description = """Sema4AI Action Server"""
 authors = [
 	"Sema4.ai, Inc. <dev@sema4.ai>",

--- a/action_server/src/sema4ai/action_server/__init__.py
+++ b/action_server/src/sema4ai/action_server/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 version_info = [int(x) for x in __version__.split(".")]
 
 __all__: List[str] = []

--- a/action_server/src/sema4ai/action_server/__init__.py
+++ b/action_server/src/sema4ai/action_server/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 version_info = [int(x) for x in __version__.split(".")]
 
 __all__: List[str] = []


### PR DESCRIPTION
## Summary
- Run manylinux wheel builds sequentially (`max-parallel: 1`) to avoid GitHub rate limiting (`HTTP 429`) when cibuildwheel downloads `virtualenv.pyz`.
- See failed run: https://github.com/Sema4AI/actions/actions/runs/22854429674/job/66293319617

🤖 Generated with [Claude Code](https://claude.com/claude-code)