### PR TITLE
Bump Action Server version to 3.2.0

### DIFF
--- a/action_server/docs/CHANGELOG.md
+++ b/action_server/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 3.2.0 - 2026-04-10
+
+- Upgrade RCC to 21.2.0.
+- Upgrade Go wrapper to Go 1.26.2, fixing 19 stdlib CVEs in crypto/tls, crypto/x509, net/http, net/url, os, os/exec, and encoding/asn1.
+- Drop manylinux wheel publishing.
+
 ## 3.1.1 - 2026-03-09
 
 - Run manylinux wheel builds sequentially to avoid GitHub rate limiting during virtualenv download.

--- a/action_server/pyproject.toml
+++ b/action_server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-action-server"
-version = "3.1.1"
+version = "3.2.0"
 description = """Sema4AI Action Server"""
 authors = [
 	"Sema4.ai, Inc. <dev@sema4.ai>",

--- a/action_server/src/sema4ai/action_server/__init__.py
+++ b/action_server/src/sema4ai/action_server/__init__.py
@@ -1,6 +1,6 @@
 from typing import List
 
-__version__ = "3.1.1"
+__version__ = "3.2.0"
 version_info = [int(x) for x in __version__.split(".")]
 
 __all__: List[str] = []


### PR DESCRIPTION
## Summary
- Bump Action Server version to 3.2.0
- Changelog entries for RCC 21.2.0 upgrade, Go wrapper CVE fixes, and manylinux wheel removal

## Test plan
- [ ] CI passes
- [ ] After merge, run `inv make-release` from master to tag and trigger release workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)